### PR TITLE
refs #66. Updated example.docker-compose.yml to change timezone.

### DIFF
--- a/docker/example.dev.docker-compose.yml
+++ b/docker/example.dev.docker-compose.yml
@@ -5,11 +5,13 @@ sfmdevrabbit:
         - "15672:15672"
     restart: always
     environment:
+        - TZ=EST
         - RABBITMQ_DEFAULT_USER=sfm_user
         - RABBITMQ_DEFAULT_PASS=password
 sfmdevdb:
     image: gwul/sfm-ui-db:master
     environment:
+        - TZ=EST
         - POSTGRES_PASSWORD=gherD42#dl5
 sfmdevapp:
     image: gwul/sfm-ui:dev
@@ -22,6 +24,7 @@ sfmdevapp:
     volumes:
         - ~/sfm-ui:/opt/sfm-ui
     environment:
+        - TZ=EST
         - SFM_DEBUG=True
         #Turn on logging
         #- SFM_DJANGO_LOG=DEBUG

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -57,6 +57,8 @@ Configuration
   If setting ``DEBUG`` to false, the ``ALLOWED_HOSTS`` environment variable must be provided with a
   comma-separated list of hosts.  See the `Django documentation <https://docs.djangoproject.com/en/1.8/ref/settings/#allowed-hosts>`_
   for ``ALLOWED_HOSTS``.
+* The default timezone is Eastern Standard Time (EST). To select a different timezone, change ``TZ=EST`` in
+  ``docker-compose.yml``.
 * The `data volume strategy <https://docs.docker.com/engine/userguide/dockervolumes/#creating-and-mounting-a-data-volume-container>`_
   is used to manage the volumes that store SFM's data. By default, normal Docker volumes are used; to use
   a host volume instead, add the host directory to the ``volumes`` field.  This will allow you to access the

--- a/sfm/sfm/settings/common.py
+++ b/sfm/sfm/settings/common.py
@@ -103,7 +103,7 @@ SCHEDULER_DB_URL = "postgresql://{USER}:{PASSWORD}@{HOST}/{NAME}".format(**DATAB
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = env.get('CONTAINER_TIMEZONE')
 
 USE_I18N = True
 


### PR DESCRIPTION
In this we just have to update our docker-compose.yml and include following volumes in each container to have local time synced your machine's time:

volumes:
- /etc/localtime:/etc/localtime:ro
- /etc/timezone:/etc/timezone:ro

Let me know if we need to use the other approach we discussed here : https://github.com/gwu-libraries/sfm-ui/issues/66

I have updated example.dev.docker-compose.yml accordingly for reference.

