### PR TITLE
Added tests for Credential UI forms. closes #179

### DIFF
--- a/sfm/ui/test_forms.py
+++ b/sfm/ui/test_forms.py
@@ -4,8 +4,9 @@ import pytz
 from django.contrib.auth.models import Group
 from django.test import TestCase, RequestFactory
 
-from .forms import CollectionForm, SeedSetForm, SeedForm
-from .views import CollectionUpdateView
+from .forms import CollectionForm, SeedSetForm, SeedForm, CredentialWeiboForm
+from .forms import CredentialFlickrForm, CredentialTwitterForm, CredentialForm
+from .views import CollectionUpdateView, CredentialUpdateView
 from .models import User, Collection, Credential, SeedSet, Seed
 
 
@@ -162,4 +163,94 @@ class SeedFormTest(TestCase):
 
     def test_valid_from(self):
         form = SeedForm(self.data, seedset=self.seedset.pk)
+        self.assertTrue(form.is_valid())
+
+
+class CredentialFlickrFormTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        user = User.objects.create_superuser(username="test_user",
+                                             email="test_user@test.com",
+                                             password="test_password")
+        self.data = {
+            "name": "test_flickr_credential",
+            "user": user.pk,
+            "platform": "flickr",
+            "key":"dummy_key",
+            "secret":"dummy_secret",
+            "date_added": "04/14/2016",
+        }
+
+    def test_valid_form(self):
+        form = CredentialFlickrForm(self.data)
+        self.assertTrue(form.is_valid())
+
+
+class CredentialTwitterFormTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        user = User.objects.create_superuser(username="test_user",
+                                             email="test_user@test.com",
+                                             password="test_password")
+        self.data = {
+            "name": "test_twitter_credential",
+            "user": user.pk,
+            "platform": "twitter",
+            "consumer_key": "dummy_consumer_key",
+            "consumer_secret": "dummy_consumer_secret",
+            "access_token": "dummy_access_token",
+            "access_token_secret": "dummy_access_token_secret",
+            "date_added": "04/14/2016",
+        }
+
+    def test_valid_form(self):
+        form = CredentialTwitterForm(self.data)
+        self.assertTrue(form.is_valid())
+
+
+class CredentialWeiboFormTest(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        user = User.objects.create_superuser(username="test_user",
+                                             email="test_user@test.com",
+                                             password="test_password")
+        self.data = {
+            "name": "test_weibo_credential",
+            "user": user.pk,
+            "platform": "weibo",
+            "api_key": "dummy_api_key",
+            "api_secret": "dummy_api_secret",
+            "redirect_uri": "dummy_redirect_uri",
+            "access_token": "dummy_access_token",
+            "date_added": "04/14/2016",
+        }
+
+    def test_valid_form(self):
+        form = CredentialWeiboForm(self.data)
+        self.assertTrue(form.is_valid())
+
+
+class CredentialUpdateFormTest(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        user = User.objects.create_superuser(username="test_user",
+                                             email="test_user@test.com",
+                                             password="test_password")
+        self.credential = Credential.objects.create(user=user,
+                                                    name='Test Credential',
+                                                    platform='test platform',
+                                                    token='{"key1":"key1","key2":"key2"}')
+        self.path = '/ui/credentials/' + str(self.credential.pk) + '/update/'
+
+    def test_valid_data(self):
+        request = self.factory.get(self.path)
+        response = CredentialUpdateView.as_view()(request,
+                                                  pk=self.credential.pk)
+        form = CredentialForm({
+            'name': 'my test credential updated name',
+            'token': '{"key1":"updated_key1","key2","update_key2"}',
+            'history_note': 'Test Update'
+        })
+        self.assertEqual(response.status_code, 200)
         self.assertTrue(form.is_valid())


### PR DESCRIPTION
@lwrubel Please check these test for credential UI forms and let me know if i am missing something.

NOTE:  This branch doesnt have tests for checking the way token is saved in database from various Credential forms for now as i have another PR https://github.com/gwu-libraries/sfm-ui/pull/192 which tweaks that field before saving.

@kerchner Can you please put PR https://github.com/gwu-libraries/sfm-ui/pull/192 on hold for now as i would like to add tests for Token field in credential forms there.