### PR TITLE
T233 DateTime Picker - Added Datetimepicker in seedset form. closes #223

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -30,3 +30,4 @@ urllib3==1.14
 warc==0.2.1
 djangorestframework==3.3.2
 django-filter==0.12.0
+django-datetime-widget==0.9.3

--- a/sfm/sfm/settings/common.py
+++ b/sfm/sfm/settings/common.py
@@ -50,7 +50,8 @@ INSTALLED_APPS = [
     'message_consumer',             # Message Consumer
     'simple_history',
     'rest_framework',               # For REST API
-    'api'
+    'api',
+    'datetimewidget'
 ]
 
 MIDDLEWARE_CLASSES = (

--- a/sfm/ui/forms.py
+++ b/sfm/ui/forms.py
@@ -6,6 +6,7 @@ from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, Button, Submit
 from crispy_forms.bootstrap import FormActions
 from .models import Collection, SeedSet, Seed, Credential, Export
+from datetimewidget.widgets import DateTimeWidget
 
 import json
 import logging
@@ -73,6 +74,16 @@ class SeedSetForm(forms.ModelForm):
         widgets = {'collection': forms.HiddenInput,
                    'date_added': forms.HiddenInput,
                    'is_active': forms.HiddenInput,
+                   'start_date': DateTimeWidget(
+                       usel10n=True,
+                       bootstrap_version=3,
+                       attrs={'data-readonly': 'false'}
+                   ),
+                   'end_date': DateTimeWidget(
+                       usel10n=True,
+                       bootstrap_version=3,
+                       attrs={'data-readonly': 'false'}
+                   ),
                    'history_note': HISTORY_NOTE_WIDGET}
         localized_fields = None
         labels = {

--- a/sfm/ui/templates/base.html
+++ b/sfm/ui/templates/base.html
@@ -18,12 +18,27 @@
     <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
 
     <!-- Optional theme -->
-    <link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
+	<link rel="stylesheet" href="https://netdna.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
 
 	<!-- Your stuff: Third-party css libraries go here -->
 
 	<!-- This file store project specific CSS -->
-    {% endblock %}
+
+	{% endblock %}
+
+	{% block javascript %}
+
+	<!-- Latest JQuery -->
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+
+	<!-- Latest compiled and minified JavaScript -->
+	<script src="https://netdna.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+
+	<!-- Your stuff: Third-party javascript libraries go here -->
+
+	<!-- place project specific Javascript in this file -->
+
+	{% endblock %}
 
   </head>
 
@@ -86,20 +101,6 @@
 
     {% block modal %}{% endblock modal %}
 
-    <!-- Le javascript
-    ================================================== -->
-    <!-- Placed at the end of the document so the pages load faster -->
-    {% block javascript %}
-      <!-- Latest JQuery -->
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-
-      <!-- Latest compiled and minified JavaScript -->
-      <script src="https://netdna.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-
-      <!-- Your stuff: Third-party javascript libraries go here -->
-
-      <!-- place project specific Javascript in this file -->
-    {% endblock javascript %}
     <div class="footer" id="footer">GW Libraries</div>
   </body>
 </html>


### PR DESCRIPTION
@lwrubel I have added Datetime picker on Seedset form screens. We can configure it a bit more by adding attr in forms.py
Eg.,
'start_date': DateTimeWidget(usel10n=True, bootstrap_version=3),

can be changed to 
'start_date': DateTimeWidget(attrs={'id':"yourdatetimeid"}, usel10n=True, bootstrap_version=3),

id values:
'0' for the hour view
'1' for the day view
'2' for month view (the default)
'3' for the 12-month overview
'4' for the 10-year overview. Useful for date-of-birth datetimepickers.

Please refer https://github.com/asaglimbeni/django-datetime-widget for more.

Right now we are using default month view

Let me know if you require any change in this.