### PR TITLE
T156 diffs layouts

### DIFF
--- a/sfm/ui/models.py
+++ b/sfm/ui/models.py
@@ -188,7 +188,7 @@ class SeedSet(models.Model):
 
         Web harvests are excluded.
         """
-        return self.harvests.exclude(harvest_type = "web").order_by("-date_requested").first()
+        return self.harvests.exclude(harvest_type="web").order_by("-date_requested").first()
 
     def is_streaming(self):
         """
@@ -267,8 +267,8 @@ class Harvest(models.Model):
 
     def message_count(self):
         return len(self.infos) if self.infos else 0 \
-               + len(self.warnings) if self.warnings else 0 \
-               + len(self.errors) if self.errors else 0
+            + len(self.warnings) if self.warnings else 0 \
+            + len(self.errors) if self.errors else 0
 
 
 class Warc(models.Model):

--- a/sfm/ui/templates/ui/change_log.html
+++ b/sfm/ui/templates/ui/change_log.html
@@ -1,0 +1,73 @@
+{% extends 'base.html' %}
+{% block title %}
+    Change Log 
+{% endblock %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-12">
+        <ol class="breadcrumb">
+            {% if model_name == "credential" %}
+                <li><a href="{% url 'credential_list' %}">My Credentials</a></li>
+                <li><a href="{% url 'credential_detail' item.id %}">{{ name }}</a></li>
+            {% elif model_name == "collection" %}
+                <li><a href="{% url 'collection_list' %}">My Collections</a></li>
+                <li><a href="{% url 'collection_detail' item.id %}">{{ name }}</a></li>
+            {% elif model_name == "seedset" %}
+                <li><a href="{% url 'collection_list' %}">My Collections</a></li>
+                <li><a href="{% url 'collection_detail' item.collection.id %}">{{ item.collection.name }}</a></li>
+                <li><a href="{% url 'seedset_detail' item.id %}">{{ name }}</a></li>
+            {% elif model_name == "seed" %}
+                <li><a href="{% url 'collection_list' %}">My Collections</a></li> 
+                <li><a href="{% url 'collection_detail' item.seed_set.collection.id %}">{{ item.seed_set.collection.name }}</a></li>
+                <li><a href="{% url 'seedset_detail' item.seed_set.id %}">{{ item.seed_set.name }}</a></li>
+                <li><a href="{% url 'seed_detail' item.id %}">{{ name }}</a></li>
+            {% endif %}
+            <li class="active">Change Log</li>
+         </ol>
+     </div>
+</div>
+
+<div class="row">
+   <div class="col-md-12">
+       <h2>Change log for {{model_name }} {{ name }}</h2>
+   </div>
+</div>
+<div class="row">
+  <div class="col-md-12">
+    <nav>
+    <ul class="pager">
+        {% if diffs_page.has_previous %}
+            <li><a href="?page={{ diffs_page.previous_page_number }}">Previous</a></li>
+        {% endif %}
+        Page {{ diffs_page.number }} of {{ paginator.num_pages }}
+        {% if diffs_page.has_next %}
+            <li><a href="?page={{ diffs_page.next_page_number }}">Next</a></li>
+        {% endif %}
+    </ul>
+    </nav>
+  </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        <table class="table">
+            <tr>
+               <th>Date</th>
+               <th>User</th>
+               <th>Fields</th>
+            </tr>
+          {% for diff in diffs_page %}
+            <tr>
+               <td>{{ diff.date }}</td>
+               <td>{{ diff.user|default_if_none:"system" }}</td>
+               <td>
+                  {% for key, values in diff.fields.iteritems %}
+                  {{ key }}: "{{ values.0|default_if_none:"blank" }}" changed to "{{ values.1 }}" <br/>
+                  {% endfor %}
+                  {% if diff.note %}<strong>Note:</strong> {{ diff.note}}{% endif %}</td>
+            </tr>
+          {% endfor %}
+         </table>
+     </div>
+ </div>
+{% endblock %}

--- a/sfm/ui/templates/ui/collection_detail.html
+++ b/sfm/ui/templates/ui/collection_detail.html
@@ -32,9 +32,6 @@
             {% endfor %}
         </ul></p>
     {% endif %}
-    <p>Changes:
-        {% include "ui/diff_snippet.html" with log_entries=seedset.log_entries %}
-    </p>
     </div>
 </div>
 <div class="row">
@@ -65,6 +62,12 @@
                 <a class="btn btn-primary" value="Add {{ harvest_label }}" href="{% url "seedset_create" collection.id harvest_type %}">Add {{ harvest_label }}</a>
             {% endfor %}
         </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        <h4>Change log</h4>
+        {% include "ui/diff_snippet.html" with log_entries=collection.log_entries %}
     </div>
 </div>
 {% endblock %}

--- a/sfm/ui/templates/ui/credential_detail.html
+++ b/sfm/ui/templates/ui/credential_detail.html
@@ -27,9 +27,11 @@
         {{ credential.token|json }}
         <p><strong>Date Added:</strong> {{ credential.date_added }}</p>
         <p><strong>Active:</strong> {{ credential.is_active|yesno:"Yes,No" }}</p>
-        <p><strong>Diffs:</strong>
-                {% include "ui/diff_snippet.html" with log_entries=seedset.log_entries %}
-                 </p>
+        <p><strong>Change log ({{ diffs|length }}):</strong> <a href="#diffList" data-toggle="collapse" aria-expanded="false" aria-controls="diffList">View</a> 
+            <div class="collapse" id="diffList">
+            {% include "ui/diff_snippet.html" with log_entries=credential.log_entries %}
+            </div>
+        </p>
    </div>
 </div>
 {% endblock %}

--- a/sfm/ui/templates/ui/diff_snippet.html
+++ b/sfm/ui/templates/ui/diff_snippet.html
@@ -1,12 +1,26 @@
-<ul>
-    {% for diff in diffs %}
-        <li>Updated on {{ diff.date }} by {{ diff.user }}.{% if diff.note %} Note is "{{ diff.note }}".{% endif %}</li>
-        <ul>
+<table class="table">
+    <tr>
+        <th>Date</th>
+        <th>User</th>
+        <th>Fields</th>
+    </tr>
+    {% for diff in diffs|slice:"3" %}
+    <tr>
+        <td>{{ diff.date }}</td>
+        <td>{{ diff.user|default_if_none:"system" }}</td>
+        <td>
             {% for key, values in diff.fields.iteritems %}
-                <li>{{ key }}: "{{ values.0|default_if_none:"" }}" changed to "{{ values.1 }}"</li>
+                {{ key }}: "{{ values.0|default_if_none:"blank" }}" changed to "{{ values.1 }}" <br/>
             {% endfor %}
-        </ul>
+            {% if diff.note %}<strong>Note:</strong> {{ diff.note}}{% endif %}
+        </td>
+    </tr>
     {% empty %}
-    <li>No changes yet.</li>
+    <tr><td colspan="4">No changes yet.</td></tr>
     {% endfor %}
-</ul>
+    {% if diffs|length > 3 %}
+    <tr><td colspan="4">
+            <a href="{% url 'change_log' model_name item_id %}">View all {{ diffs|length }} changes</a>
+    </td></tr>
+    {% endif %}
+</table>

--- a/sfm/ui/templates/ui/harvest_list.html
+++ b/sfm/ui/templates/ui/harvest_list.html
@@ -19,7 +19,7 @@
 		{% if page_obj.has_previous %}
 			<li><a href="?page={{ page_obj.previous_page_number }}">Previous</a></li>
 		{% endif %}
-		Page {{ page_obj.number }} of {{ paginator.num_pages }}.
+		Page {{ page_obj.number }} of {{ paginator.num_pages }}
 		{% if page_obj.has_next %}
 			<li><a href="?page={{ page_obj.next_page_number }}">Next</a></li>
 		{% endif %}

--- a/sfm/ui/templates/ui/seed_detail.html
+++ b/sfm/ui/templates/ui/seed_detail.html
@@ -19,7 +19,7 @@
    <div class="row">
        <div class="col-md-12">
             <div class="page-header">
-               <h1>{{ seed.seed_set.get_harvest_type_display }} seed<a class="btn btn-default" href={% url "seed_update" seed.pk %} {% if seed.seed_set.is_active %}disabled="disabled"{% endif %}>Edit</a></h1>
+               <h1>{{ seed.seed_set.get_harvest_type_display }} <a class="btn btn-default" href={% url "seed_update" seed.pk %} {% if seed.seed_set.is_active %}disabled="disabled"{% endif %}>Edit</a></h1>
                {% if seed.seed_set.is_active %}<span class="label label-warning">Pause seedset harvesting to enable editing.</span>{% endif %}
             </div>
        </div>
@@ -36,8 +36,13 @@
             <p><strong>Date updated:</strong> {{ seed.date_updated }}</p>
             <p><strong>Date added</strong> {{ seed.date_added }}</p>
             <p><strong>Diffs:</strong></p>
-            {% include "ui/diff_snippet.html" with log_entries=seedset.log_entries %}
             </p>
        </div>
-    </div>
+   </div>
+   <div class="row">
+       <div class="col-md-12">
+          <h4>Change log</h4>
+          {% include "ui/diff_snippet.html" with log_entries=seed.log_entries %}
+       </div>
+   </div>
 {% endblock %}

--- a/sfm/ui/templates/ui/seedset_detail.html
+++ b/sfm/ui/templates/ui/seedset_detail.html
@@ -35,7 +35,6 @@
         <p><strong>End date: </strong> {{ seedset.end_date }}</p>
         <p><strong>Created:</strong> {{ seedset.date_added }}</p>
         <p><strong>Description:</strong> {{seedset.description }}</p>
-        <p><strong>Harvests: </strong> {{ harvests }}</p>
         {% if seedset.stats %}
             <p><strong>Stats:</strong><ul>
                 {% for item, count in seedset.stats.items %}
@@ -43,9 +42,6 @@
                 {% endfor %}
             </ul></p>
         {% endif %}
-        <p><strong>Diffs:</strong>
-                {% include "ui/diff_snippet.html" with log_entries=seedset.log_entries %}
-                 </p>         
    </div>
 </div>
 {% if has_seeds_list %}
@@ -82,7 +78,7 @@
 {% if harvests %}
 <div class="row">
     <div class="panel panel-default">
-        <div class="panel-heading"><h4>Harvests</h4> ({{ harvests|length }} of {{ harvest_count }})</div>
+        <div class="panel-heading"><h4>Harvests</h4> (1-{{ harvests|length }} of {{ harvest_count }})</div>
         <div class="panel-body">
             <table class="table">
                 <thead>
@@ -104,32 +100,38 @@
             </table>
         </div>
         {% if harvest_count > harvests|length %}
-            <div class="panel-footer"><a href="{% url "seedset_harvests" seedset.pk %}">More harvests ...</a></div>
+        <div class="panel-footer"><a href="{% url "seedset_harvests" seedset.pk %}">View all {{ harvest_count }} harvests</a></div>
         {% endif %}
     </div>
 </div>
 {% endif %}
 
 <div class="row">
-  <div class="col-md-12">
-        <form method="post" action="{% url "seedset_toggle_active" seedset.id %}">
-            {% csrf_token %}
+  <div class="col-md-2">
+        <form method="post" action={% url "seedset_toggle_active" seedset.pk %}>
+            {% csrf_token %}<p>
             {% if seedset.is_active %}
-                <input type="submit" value="Pause harvesting" class="btn btn-primary">
+                <input type="submit" value="Pause Harvesting" class="btn btn-primary">
             {% else %}
                 {% if not seed_count_message %}
-                    <input type="submit" value="Start/resume harvesting" class="btn btn-primary">
+                    <input type="submit" value="Start/resume Harvesting" class="btn btn-primary">
                 {% else %}
-                    <input type="submit" value="Start/resume harvesting" class="btn btn-primary" disabled="disabled">
+                    <input type="submit" value="Start/resume Harvesting" class="btn btn-primary" disabled="disabled">
                     <span class="label label-warning">{{ seed_count_message }}</span>
                 {% endif %}
-            {% endif %}
+            {% endif %}</p>
         </form>
     </div>
 </div>
 <div class="row">
-	<div class="col-md-12">
+    <div class="col-md-12">
 		<p><a class="btn btn-primary" value="Request Export"{% if not can_export %} disabled {% endif %} href="{% url "export_create" seedset.id %}">Request Export</a></p>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-12">
+        <h4>Change log</h4>
+        {% include "ui/diff_snippet.html" with log_entries=seedset.log_entries %}
     </div>
 </div>
 {% endblock %}

--- a/sfm/ui/urls.py
+++ b/sfm/ui/urls.py
@@ -107,7 +107,9 @@ urlpatterns = patterns('',
 
                        url(r'^harvests/(?P<pk>\d+)/$',
                            views.HarvestDetailView.as_view(),
-                           name="harvest_detail")
+                           name="harvest_detail"),
 
+                       url(r'^(?P<model>\w+)/(?P<item_id>\d+)/changes/$',
+                           views.ChangeLogView.as_view(),
+                           name="change_log"),
                        )
-


### PR DESCRIPTION
Fixes #156. Puts first three diff items in collapsed table on detail views for Collection, SeedSet, Seed, Credential. If more than three diffs, provides link to a Change Log page with all changes in a table. 

The Change Log page has to do a query on the correct model, so passing the model name and id via a slug in the URL. Open to ideas on how to do this better, if this is too clunky. 
