### PR TITLE
T234 added ability to view all collections to superadmin. closes #234

### DIFF
--- a/sfm/ui/templates/ui/collection_list.html
+++ b/sfm/ui/templates/ui/collection_list.html
@@ -7,17 +7,29 @@
 <div class="row">
     <h1>My Collections</h1>
 </div>
-        <div class="row">
-            {% for collection in collection_list %}
-            <div class="col-md-4"><p><a href={% url "collection_detail" collection.pk %}>{{ collection.name }}</a></p></div>
-            <div class="col-md-3"><p>{{ collection.num_seedsets }} seedset{{ collection.num_seedsets|pluralize}}</p></div>
-            <div class="col-md-4"><p>Created {{ collection.date_added }}</p></div>
-            <!-- later add date of most recent harvest from among collection's seedsets -->
-            <div class="col-md-1"><p>{{ collection.group }}</p></div>
-            {% empty %}
-            <div class="col-md-12"><p>No collections yet.</p></div>
-            {% endfor %}
-        </div>
+<div class="row">
+    {% for collection in collection_list %}
+        <div class="col-md-4"><p><a href={% url "collection_detail" collection.pk %}>{{ collection.name }}</a></p></div>
+        <div class="col-md-3"><p>{{ collection.num_seedsets }} seedset{{ collection.num_seedsets|pluralize}}</p></div>
+        <div class="col-md-4"><p>Created {{ collection.date_added }}</p></div>
+        <!-- later add date of most recent harvest from among collection's seedsets -->
+        <div class="col-md-1"><p>{{ collection.group }}</p></div>
+    {% empty %}
+        <div class="col-md-12"><p>No collections yet.</p></div>
+	{% endfor %}
+	{% if user.is_superuser %}
+		<h1>Other Collections</h1>
+		{% for collection in collection_list_n %}
+			<div class="col-md-4"><p><a href={% url "collection_detail" collection.pk %}>{{ collection.name  }}</a></p></div>
+			<div class="col-md-3"><p>{{ collection.num_seedsets  }} seedset{{ collection.num_seedsets|pluralize }}</p></div>
+			<div class="col-md-4"><p>Created {{ collection.date_added  }}</p></div>
+			<!-- later add date of most recent harvest from among collection's seedsets -->
+			<div class="col-md-1"><p>{{ collection.group  }}</p></div>
+		{% empty %}
+			<div class="col-md-12"><p>No collections yet.</p></div>
+		{% endfor %}
+	{% endif %}
+</div>
 <div class="row">
     <div class="col-md-12">
         <div class="btn-toolbar" style="padding-top: 15px">

--- a/sfm/ui/views.py
+++ b/sfm/ui/views.py
@@ -29,10 +29,14 @@ class CollectionListView(LoginRequiredMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super(CollectionListView, self).get_context_data(**kwargs)
+        if self.request.user.is_superuser:
+            context['collection_list_n'] = Collection.objects.exclude(
+                group__in=self.request.user.groups.all()).annotate(
+                num_seedsets=Count('seed_sets')).order_by('date_updated')
+
         context['collection_list'] = Collection.objects.filter(
             group__in=self.request.user.groups.all()).annotate(
-            num_seedsets=Count('seed_sets')).order_by(
-            'date_updated')
+            num_seedsets=Count('seed_sets')).order_by('date_updated')
         return context
 
 


### PR DESCRIPTION
This allows superadmin user to view all collections at collection list screen:

Steps to test:
1. Login to sfm-ui via superadmin
2. Create collection with group in which superadmin is a member and a collection to which superadmin is not a member.
3. Check collection list view.

Expected result:
Collections that are associated with a group that the superadmin is a member of are listed separately from collections that are associated with a group that the superadmin is not a member of.