### PR TITLE
T184 credential visibility

### DIFF
--- a/sfm/ui/admin.py
+++ b/sfm/ui/admin.py
@@ -39,10 +39,10 @@ class UserAdmin(AuthUserAdmin):
 
 
 class Credential(a.ModelAdmin):
-    fields = ('user', 'platform', 'token', 'is_active', 'date_added', 'history_note')
-    list_display = ['user', 'platform', 'token', 'is_active', 'date_added']
-    list_filter = ['user', 'platform', 'token', 'is_active', 'date_added']
-    search_fields = ['user', 'platform', 'token', 'is_active', 'date_added']
+    fields = ('user', 'platform', 'name', 'token', 'is_active', 'date_added', 'history_note')
+    list_display = ['user', 'platform', 'name', 'is_active', 'date_added']
+    list_filter = ['user', 'platform', 'is_active', 'date_added']
+    search_fields = ['user', 'platform', 'name', 'is_active', 'date_added']
 
 
 class HistoricalCredential(a.ModelAdmin):

--- a/sfm/ui/forms.py
+++ b/sfm/ui/forms.py
@@ -79,7 +79,13 @@ class CollectionForm(forms.ModelForm):
         )
 
 
+class NameModelChoiceField(forms.ModelChoiceField):
+    def label_from_instance(self, obj):
+        return obj.name
+
+
 class BaseSeedSetForm(forms.ModelForm):
+    credential = NameModelChoiceField(None)
 
     class Meta:
         model = SeedSet
@@ -99,7 +105,9 @@ class BaseSeedSetForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.coll = kwargs.pop("coll", None)
+        self.credential_list = kwargs.pop('credential_list', None)
         super(BaseSeedSetForm, self).__init__(*args, **kwargs)
+        self.fields['credential'].queryset = self.credential_list
         cancel_url = reverse('collection_detail', args=[self.coll])
         self.helper = FormHelper(self)
         self.helper.layout = Layout(
@@ -138,11 +146,7 @@ class SeedSetTwitterUserTimelineForm(BaseSeedSetForm):
                                               label=TWITTER_WEB_RESOURCES_LABEL)
 
     def __init__(self, *args, **kwargs):
-        request = kwargs.pop('request')
         super(SeedSetTwitterUserTimelineForm, self).__init__(*args, **kwargs)
-        self.fields['credential'].queryset = Credential.objects.filter(
-            platform='twitter', user=User.objects.filter(
-                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('incremental', 'media_option', 'web_resources_option'))
 
         if self.instance and self.instance.harvest_options:
@@ -175,11 +179,7 @@ class SeedSetTwitterSearchForm(BaseSeedSetForm):
                                               label=TWITTER_WEB_RESOURCES_LABEL)
 
     def __init__(self, *args, **kwargs):
-        request = kwargs.pop('request')
         super(SeedSetTwitterSearchForm, self).__init__(*args, **kwargs)
-        self.fields['credential'].queryset = Credential.objects.filter(
-            platform='twitter', user=User.objects.filter(
-                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('incremental', 'media_option', 'web_resources_option'))
 
         if self.instance and self.instance.harvest_options:
@@ -214,11 +214,7 @@ class SeedSetTwitterSampleForm(BaseSeedSetForm):
         exclude = ('schedule_minutes',)
 
     def __init__(self, *args, **kwargs):
-        request = kwargs.pop('request')
         super(SeedSetTwitterSampleForm, self).__init__(*args, **kwargs)
-        self.fields['credential'].queryset = Credential.objects.filter(
-            platform='twitter', user=User.objects.filter(
-                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('media_option', 'web_resources_option'))
         if self.instance and self.instance.harvest_options:
             harvest_options = json.loads(self.instance.harvest_options)
@@ -251,11 +247,7 @@ class SeedSetTwitterFilterForm(BaseSeedSetForm):
         exclude = ('schedule_minutes',)
 
     def __init__(self, *args, **kwargs):
-        request = kwargs.pop('request')
         super(SeedSetTwitterFilterForm, self).__init__(*args, **kwargs)
-        self.fields['credential'].queryset = Credential.objects.filter(
-            platform='twitter', user=User.objects.filter(
-                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('incremental', 'media_option', 'web_resources_option'))
 
         if self.instance and self.instance.harvest_options:
@@ -294,11 +286,7 @@ class SeedSetFlickrUserForm(BaseSeedSetForm):
     incremental = forms.BooleanField(initial=True, required=False, help_text=INCREMENTAL_HELP, label=INCREMENTAL_LABEL)
 
     def __init__(self, *args, **kwargs):
-        request = kwargs.pop('request')
         super(SeedSetFlickrUserForm, self).__init__(*args, **kwargs)
-        self.fields['credential'].queryset = Credential.objects.filter(
-            platform='flickr', user=User.objects.filter(
-                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('sizes', 'incremental'))
 
         if self.instance and self.instance.harvest_options:
@@ -324,11 +312,7 @@ class SeedSetWeiboTimelineForm(BaseSeedSetForm):
     incremental = forms.BooleanField(initial=True, required=False, help_text=INCREMENTAL_HELP, label=INCREMENTAL_LABEL)
 
     def __init__(self, *args, **kwargs):
-        request = kwargs.pop('request')
         super(SeedSetWeiboTimelineForm, self).__init__(*args, **kwargs)
-        self.fields['credential'].queryset = Credential.objects.filter(
-            platform='weibo', user=User.objects.filter(
-                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].append('incremental')
 
         if self.instance and self.instance.harvest_options:

--- a/sfm/ui/forms.py
+++ b/sfm/ui/forms.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 from crispy_forms.helper import FormHelper
 from crispy_forms.layout import Layout, Fieldset, Button, Submit, Div
 from crispy_forms.bootstrap import FormActions
-from .models import Collection, SeedSet, Seed, Credential, Export
+from .models import Collection, SeedSet, Seed, Credential, Export, User
 from datetimewidget.widgets import DateTimeWidget
 from .utils import clean_token
 
@@ -138,7 +138,11 @@ class SeedSetTwitterUserTimelineForm(BaseSeedSetForm):
                                               label=TWITTER_WEB_RESOURCES_LABEL)
 
     def __init__(self, *args, **kwargs):
+        request = kwargs.pop('request')
         super(SeedSetTwitterUserTimelineForm, self).__init__(*args, **kwargs)
+        self.fields['credential'].queryset = Credential.objects.filter(
+            platform='twitter', user=User.objects.filter(
+                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('incremental', 'media_option', 'web_resources_option'))
 
         if self.instance and self.instance.harvest_options:
@@ -171,7 +175,11 @@ class SeedSetTwitterSearchForm(BaseSeedSetForm):
                                               label=TWITTER_WEB_RESOURCES_LABEL)
 
     def __init__(self, *args, **kwargs):
+        request = kwargs.pop('request')
         super(SeedSetTwitterSearchForm, self).__init__(*args, **kwargs)
+        self.fields['credential'].queryset = Credential.objects.filter(
+            platform='twitter', user=User.objects.filter(
+                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('incremental', 'media_option', 'web_resources_option'))
 
         if self.instance and self.instance.harvest_options:
@@ -206,7 +214,11 @@ class SeedSetTwitterSampleForm(BaseSeedSetForm):
         exclude = ('schedule_minutes',)
 
     def __init__(self, *args, **kwargs):
+        request = kwargs.pop('request')
         super(SeedSetTwitterSampleForm, self).__init__(*args, **kwargs)
+        self.fields['credential'].queryset = Credential.objects.filter(
+            platform='twitter', user=User.objects.filter(
+                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('media_option', 'web_resources_option'))
         if self.instance and self.instance.harvest_options:
             harvest_options = json.loads(self.instance.harvest_options)
@@ -239,7 +251,11 @@ class SeedSetTwitterFilterForm(BaseSeedSetForm):
         exclude = ('schedule_minutes',)
 
     def __init__(self, *args, **kwargs):
+        request = kwargs.pop('request')
         super(SeedSetTwitterFilterForm, self).__init__(*args, **kwargs)
+        self.fields['credential'].queryset = Credential.objects.filter(
+            platform='twitter', user=User.objects.filter(
+                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('incremental', 'media_option', 'web_resources_option'))
 
         if self.instance and self.instance.harvest_options:
@@ -278,7 +294,11 @@ class SeedSetFlickrUserForm(BaseSeedSetForm):
     incremental = forms.BooleanField(initial=True, required=False, help_text=INCREMENTAL_HELP, label=INCREMENTAL_LABEL)
 
     def __init__(self, *args, **kwargs):
+        request = kwargs.pop('request')
         super(SeedSetFlickrUserForm, self).__init__(*args, **kwargs)
+        self.fields['credential'].queryset = Credential.objects.filter(
+            platform='flickr', user=User.objects.filter(
+                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].extend(('sizes', 'incremental'))
 
         if self.instance and self.instance.harvest_options:
@@ -304,7 +324,11 @@ class SeedSetWeiboTimelineForm(BaseSeedSetForm):
     incremental = forms.BooleanField(initial=True, required=False, help_text=INCREMENTAL_HELP, label=INCREMENTAL_LABEL)
 
     def __init__(self, *args, **kwargs):
+        request = kwargs.pop('request')
         super(SeedSetWeiboTimelineForm, self).__init__(*args, **kwargs)
+        self.fields['credential'].queryset = Credential.objects.filter(
+            platform='weibo', user=User.objects.filter(
+                groups=Group.objects.filter(pk__in=request.user.groups.all())))
         self.helper.layout[0][2].append('incremental')
 
         if self.instance and self.instance.harvest_options:

--- a/sfm/ui/models.py
+++ b/sfm/ui/models.py
@@ -132,6 +132,14 @@ class SeedSet(models.Model):
         TWITTER_SAMPLE: 0,
         WEIBO_TIMELINE: 0
     }
+    HARVEST_TYPES_TO_PLATFORM = {
+        TWITTER_SEARCH: Credential.TWITTER,
+        TWITTER_FILTER: Credential.TWITTER,
+        TWITTER_USER_TIMELINE: Credential.TWITTER,
+        TWITTER_SAMPLE: Credential.TWITTER,
+        FLICKR_USER: Credential.FLICKR,
+        WEIBO_TIMELINE: Credential.WEIBO
+    }
     STREAMING_HARVEST_TYPES = (TWITTER_SAMPLE, TWITTER_FILTER)
     seedset_id = models.CharField(max_length=32, unique=True, default=default_uuid)
     collection = models.ForeignKey(Collection, related_name='seed_sets')

--- a/sfm/ui/templates/ui/credential_detail.html
+++ b/sfm/ui/templates/ui/credential_detail.html
@@ -17,7 +17,7 @@
 <div class="row">
    <div class="col-md-12">
      <div class="page-header">
-        <h1>{{ credential.name }} <a class="btn btn-default" href={% url "credential_update" credential.pk %}>Edit</a></h1>
+		 <h1>{{ credential.name }} <a class="btn btn-default" {% if not can_edit %} disabled {% endif %} href={% url "credential_update" credential.pk %}>Edit</a></h1>
      </div>
    </div>
 </div>

--- a/sfm/ui/test_forms.py
+++ b/sfm/ui/test_forms.py
@@ -115,12 +115,12 @@ class SeedSetFormTest(TestCase):
         }
 
     def test_valid_form(self):
-        form = SeedSetTwitterSearchForm(self.data, coll=self.collection.pk)
+        form = SeedSetTwitterSearchForm(self.data, coll=self.collection.pk, credential_list=Credential.objects.all())
         self.assertTrue(form.is_valid())
 
     def test_end_date_after_now(self):
         self.data['end_date'] = "01/01/2000"
-        form = SeedSetTwitterSearchForm(self.data, coll=self.collection.pk)
+        form = SeedSetTwitterSearchForm(self.data, coll=self.collection.pk, credential_list=Credential.objects.all())
         self.assertFalse(form.is_valid())
 
 

--- a/sfm/ui/views.py
+++ b/sfm/ui/views.py
@@ -334,6 +334,10 @@ class CredentialDetailView(LoginRequiredMixin, DetailView):
         # Call the base implementation first to get a context
         context = super(CredentialDetailView, self).get_context_data(**kwargs)
         context["diffs"] = diff_object_history(self.object)
+        if self.request.user.is_superuser or Credential.objects.get(pk=self.object.pk).user==self.request.user:
+            context["can_edit"] = True
+        else:
+            context["can_edit"] = False
         return context
 
 

--- a/sfm/ui/views.py
+++ b/sfm/ui/views.py
@@ -155,6 +155,7 @@ class SeedSetCreateView(LoginRequiredMixin, CreateView):
     def get_form_kwargs(self):
         kwargs = super(SeedSetCreateView, self).get_form_kwargs()
         kwargs["coll"] = self.kwargs["collection_pk"]
+        kwargs['request'] = self.request
         return kwargs
 
     def get_form_class(self):
@@ -356,6 +357,11 @@ class CredentialListView(LoginRequiredMixin, ListView):
     model = Credential
     template_name = 'ui/credential_list.html'
     allow_empty = True
+
+    def get_context_data(self, **kwargs):
+        context = super(CredentialListView, self).get_context_data(**kwargs)
+        context['credential_list'] = Credential.objects.filter(user=self.request.user)
+        return context
 
 
 class CredentialUpdateView(LoginRequiredMixin, UpdateView):


### PR DESCRIPTION
@justinlittman Please test this and let me know if this is what was expected of this ticket.

Steps to test:
1. Login to sfm-ui with admin. Create multiple credentials from admin interface and assign different users who own those credentials.
2. Assign the user's to different groups and common groups.

To check the visibility of credentials on credential list screen:
1. Login with a user and go to my credential screen to check that user can only view credentials which user owns. ie., which user created.

To check that Edit button on other user's credentials is disabled:
1. Type a url for credential which user doesnt own and check if it editable by user or not.

To check the available credentials on seedset create screen:
1. Go to seedset create screen.
2. Check if the available credentials in the drop down are of the corresponding harvest platform and belong to the same group to which user is a part of.

Please let me know if you want me to create an explicit map in model for harvest type and platform as we discussed on slack.