### PR TITLE
Change weibo credentials fields

### DIFF
--- a/sfm/ui/auth.py
+++ b/sfm/ui/auth.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import Group
 from django.http import HttpResponseRedirect
 from django.core.urlresolvers import reverse
 
-from .forms import CredentialTwitterForm
+from .forms import CredentialTwitterForm,CredentialWeiboForm
 from .models import Credential
 
 
@@ -31,6 +31,12 @@ class SocialAccountAdapter(DefaultSocialAccountAdapter):
                 'consumer_secret': sociallogin.token.app.secret,
                 'access_token': sociallogin.token.token,
                 'access_token_secret': sociallogin.token.token_secret,
+            })
+        elif sociallogin.token.app.provider == 'weibo':
+            form = CredentialWeiboForm({
+                'name': credential_name,
+                'platform': Credential.WEIBO,
+                'access_token': sociallogin.token.token,
             })
         else:
             assert False, "Unrecognized social login provider"

--- a/sfm/ui/forms.py
+++ b/sfm/ui/forms.py
@@ -604,29 +604,20 @@ class CredentialTwitterForm(BaseCredentialForm):
 
 
 class CredentialWeiboForm(BaseCredentialForm):
-    api_key = forms.CharField(required=True)
-    api_secret = forms.CharField(required=True)
-    redirect_uri = forms.CharField(required=True)
     access_token = forms.CharField(required=True)
 
     def __init__(self, *args, **kwargs):
         super(CredentialWeiboForm, self).__init__(*args, **kwargs)
-        self.helper.layout[0][1].extend(['api_key', 'api_secret', 'redirect_uri', 'access_token'])
+        self.helper.layout[0][1].extend([ 'access_token'])
 
         if self.instance and self.instance.token:
             token = json.loads(self.instance.token)
-            self.fields['api_key'].initial = token.get('api_key')
-            self.fields['api_secret'].initial = token.get('api_secret')
-            self.fields['redirect_uri'].initial = token.get('redirect_uri')
             self.fields['access_token'].initial = token.get('access_token')
 
     def save(self, commit=True):
         m = super(CredentialWeiboForm, self).save(commit=False)
         m.platform = Credential.WEIBO
         token = {
-            "api_key": self.cleaned_data["api_key"],
-            "api_secret": self.cleaned_data["api_secret"],
-            "redirect_uri": self.cleaned_data["redirect_uri"],
             "access_token": self.cleaned_data["access_token"],
         }
         m.token = json.dumps(token)

--- a/sfm/ui/test_forms.py
+++ b/sfm/ui/test_forms.py
@@ -217,9 +217,6 @@ class CredentialWeiboFormTest(TestCase):
             "name": "test_weibo_credential",
             "user": self.user.pk,
             "platform": "weibo",
-            "api_key": "dummy_api_key",
-            "api_secret": "dummy_api_secret",
-            "redirect_uri": "dummy_redirect_uri",
             "access_token": "dummy_access_token",
             "date_added": "04/14/2016",
         }
@@ -229,11 +226,7 @@ class CredentialWeiboFormTest(TestCase):
         form.instance.user = self.user
         self.assertTrue(form.is_valid())
         credential = form.save()
-        self.assertJSONEqual(credential.token,
-                             '{"api_key": "dummy_api_key",'
-                             '"api_secret": "dummy_api_secret",'
-                             '"redirect_uri": "dummy_redirect_uri",'
-                             '"access_token": "dummy_access_token"}')
+        self.assertJSONEqual(credential.token, '{"access_token": "dummy_access_token"}')
 
 
 class TestExportForm(TestCase):


### PR DESCRIPTION
To consider friendly use Weibo harvester, the access token is the only required parameter for calling friendship timeline. It's hard to decide whether it's necessary to keep the other three because of the complex situation in Weibo APIs.

If this merged, the Weibo harvester should merge https://github.com/gwu-libraries/sfm-weibo-harvester/tree/t269-weibo_credentials. 
If the milestone has passed, just keep this after 1.0.