### PR TITLE
Adding footer. Fixes #282.

### DIFF
--- a/sfm/ui/static/ui/css/main.css
+++ b/sfm/ui/static/ui/css/main.css
@@ -52,11 +52,13 @@ body {
     margin-left: 15px;
 }
 
-.footer {
-    position: absolute; 
-    bottom: 0; 
-    width:100%;
+footer {
+    position: relative; 
     height: 60px;
+    border-top: 1px solid #999;
+    padding-top: 10px;
+    padding-bottom: 40px;
+    font-size: 14px;
 }
 
 .sfm-container {

--- a/sfm/ui/templates/base.html
+++ b/sfm/ui/templates/base.html
@@ -98,14 +98,29 @@
     </div> <!-- /container -->
 
     {% block modal %}{% endblock modal %}
-    {% comment "Removing pending #257" %}
-    <footer>
-      <nav class="navbar navbar-default">
-        <div class="container-fluid">
-            <div class="nav navbar-header"><p>GW Libraries</p></div>
+    <div class="container"> 
+      <div class="row">
+        <div class="col-md-12">
+         <footer>
+          <nav>
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="navbar-collapse-footer" aria-expanded="false">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+            </div>
+            <div class="collapse navbar-collapse" id="navbar-collapse-footer">
+                <ul class="nav navbar-nav">
+                  <li><a href="https://sfm.readthedocs.org/en/latest/quickstart.html" target="_blank">Getting Started</a></li>
+                  <li><a href="https://sfm.readthedocs.org" target="_blank">Documentation</a></li>
+                </ul>
+            </div>
+            </nav>
+            </footer>
         </div>
-      </nav>
-    </footer>
-    {% endcomment %}
+      </div>
+    </div>
 </body>
 </html>


### PR DESCRIPTION
Footer with links to Getting Started and Documentation. Link to Getting Started assumes the quickstart.rst file will be available on readthedocs. 