### PR TITLE
Ref #454 segment rows

### DIFF
--- a/docs/messaging_spec.rst
+++ b/docs/messaging_spec.rst
@@ -354,6 +354,7 @@ Export start messages specify the requests for an export. Example::
         "path": "/sfm-data/exports/45",
         "format": "csv",
         "dedupe": true,
+        "segment_size": 100000,
         "item_date_start": "2015-07-28T11:17:36.640178",
         "item_date_end": "2016-07-28T11:17:36.640178",
         "harvest_date_start": "2015-07-28T11:17:36.640178",
@@ -376,7 +377,8 @@ Another example::
             }
         ],
         "path": "/sfm-data/exports/45",
-        "format": "json"
+        "format": "json",
+        "segment_size": null
     }
 
 * The routing key will be `export.start.<social media platform>.<type>`. For example,
@@ -392,6 +394,8 @@ Another example::
 * `dedupe`: If true, duplicate social media content should be removed.
 * `item_date_start` and `item_date_end`: The date of social media content should be within this range.
 * `harvest_date_start` and `harvest_date_end`: The harvest date of social media content should be within this range.
+* `segment_size`: Maximum number of items to include in a single file. `null` means that all items should be placed in a
+  single file.
 
 Export status message
 ----------------------

--- a/sfm/sfm/settings/common.py
+++ b/sfm/sfm/settings/common.py
@@ -178,6 +178,9 @@ PERFORM_EXPORTS = True
 # Add a 5 minute schedule interval. This is useful for dev and testing.
 FIVE_MINUTE_SCHEDULE = env.get('SFM_FIVE_MINUTE_SCHEDULE', 'False') == 'True'
 
+# Add a 100 item export segment. This is useful for dev and testing.
+HUNDRED_ITEM_SEGMENT = env.get('SFM_HUNDRED_ITEM_SEGMENT', 'False') == 'True'
+
 # Whether to send emails.
 PERFORM_EMAILS = True
 EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
@@ -189,7 +192,6 @@ EMAIL_USE_TLS = True
 
 # Whether to run apscheduler
 RUN_SCHEDULER = env.get('SFM_RUN_SCHEDULER', 'False') == 'True'
-
 
 PERFORM_USER_HARVEST_EMAILS = env.get('SFM_PERFORM_USER_HARVEST_EMAILS', 'True') == 'True'
 USER_HARVEST_EMAILS_HOUR = env.get('SFM_USER_HARVEST_EMAILS_HOUR', '1')

--- a/sfm/ui/config.py
+++ b/sfm/ui/config.py
@@ -35,6 +35,11 @@ class UIConfig(AppConfig):
             log.debug("Adding 5 minute timer")
             Collection.SCHEDULE_CHOICES.append((5, "Every 5 minutes"))
 
+        # Add 5 minute interval
+        if settings.HUNDRED_ITEM_SEGMENT:
+            log.debug("Adding 10 item export segment")
+            Export.SEGMENT_CHOICES.append((100, "100"))
+
         if settings.RUN_SCHEDULER:
             log.debug("Running scheduler")
             sched = start_sched()

--- a/sfm/ui/export.py
+++ b/sfm/ui/export.py
@@ -42,6 +42,7 @@ def request_export(export):
         "id": export.export_id,
         "type": export.export_type,
         "format": export.export_format,
+        "segment_size": export.export_segment_size,
         "dedupe": export.dedupe,
         "path": export.path
     }

--- a/sfm/ui/forms.py
+++ b/sfm/ui/forms.py
@@ -799,7 +799,7 @@ class ExportForm(forms.ModelForm):
 
     class Meta:
         model = Export
-        fields = ['seeds', 'export_format', 'dedupe',
+        fields = ['seeds', 'export_format', 'export_segment_size', 'dedupe',
                   'item_date_start', 'item_date_end',
                   'harvest_date_start', 'harvest_date_end']
         localized_fields = None
@@ -825,6 +825,7 @@ class ExportForm(forms.ModelForm):
                 '',
                 'seeds',
                 'export_format',
+                'export_segment_size',
                 'dedupe',
                 'item_date_start',
                 'item_date_end',

--- a/sfm/ui/migrations/0011_export_export_segment_size.py
+++ b/sfm/ui/migrations/0011_export_export_segment_size.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ui', '0010_auto_20161118_0002'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='export',
+            name='export_segment_size',
+            field=models.BigIntegerField(default=250000, help_text=b'Number of items per file.', null=True, blank=True, choices=[(100000, b'100,000'), (250000, b'250,000'), (5000000, b'500,000'), (10000000, b'1,000,000'), (None, b'Single file'), (100, b'100')]),
+        ),
+    ]

--- a/sfm/ui/models.py
+++ b/sfm/ui/models.py
@@ -587,12 +587,21 @@ class Export(models.Model):
         ("json_full", "Full JSON"),
         ("dehydrate", "Text file of identifiers (dehydrate)")
     )
+    SEGMENT_CHOICES = [
+        (100000, "100,000"),
+        (250000, "250,000"),
+        (5000000, "500,000"),
+        (10000000, "1,000,000"),
+        (None, "Single file"),
+    ]
     user = models.ForeignKey(User, related_name='exports')
     collection = models.ForeignKey(Collection, blank=True, null=True)
     seeds = models.ManyToManyField(Seed, blank=True)
     export_id = models.CharField(max_length=32, unique=True, default=default_uuid)
     export_type = models.CharField(max_length=255)
     export_format = models.CharField(max_length=10, choices=FORMAT_CHOICES, default="csv")
+    export_segment_size = models.BigIntegerField(choices=SEGMENT_CHOICES, default=250000,
+                                                 help_text="Number of items per file.", null=True, blank=True)
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=NOT_REQUESTED)
     path = models.TextField(blank=True)
     date_requested = models.DateTimeField(blank=True, null=True)

--- a/sfm/ui/templates/ui/export_detail.html
+++ b/sfm/ui/templates/ui/export_detail.html
@@ -41,6 +41,7 @@
     {% endif %}
     <p><strong>Export type:</strong> {{ export.export_type }}</p>
     <p><strong>Format:</strong> {{ export.export_format }}</p>
+    <p><strong>Export segment size:</strong> {{ export.get_export_segment_size_display }}</p>
     <p><strong>Deduplicate:</strong> {{ export.dedupe }}</p>
     <p><strong>Item start date:</strong> {{ export.item_date_start }}</p>
     <p><strong>Item end date:</strong> {{ export.item_date_end }}</p>

--- a/sfm/ui/views.py
+++ b/sfm/ui/views.py
@@ -521,10 +521,10 @@ def _get_fileinfos(path):
     if os.path.exists(path):
         contents = os.listdir(path)
         for item in contents:
-            path = os.path.join(path, item)
-            if os.path.isfile(path):
-                fileinfos.append((item, os.path.getsize(path)))
-    return fileinfos
+            p = os.path.join(path, item)
+            if os.path.isfile(p):
+                fileinfos.append((item, os.path.getsize(p)))
+    return sorted(fileinfos)
 
 
 class ExportDetailView(LoginRequiredMixin, DetailView):


### PR DESCRIPTION
Ref https://github.com/gwu-libraries/sfm-ui/issues/454 Sfm-UI providing segment row size choice:`("100,000", "250,000", "500,000","1,000,000","All in one")`.
* adding `segment_size` into the message info
* display exporting files in number order
* fix test cases with mutilp file view

Other related PRs:
https://github.com/gwu-libraries/sfm-utils/pull/24
https://github.com/gwu-libraries/sfm-tumblr-harvester/pull/6
https://github.com/gwu-libraries/sfm-flickr-harvester/pull/10
https://github.com/gwu-libraries/sfm-weibo-harvester/pull/22
https://github.com/gwu-libraries/sfm-twitter-harvester/pull/26
