### PR TITLE
Documentation for AWS template: Host Docker Volume saves to .env

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -93,8 +93,8 @@ statements change *master* to the correct version, e.g., *1.7.0*::
     # - echo TZ=America/New_York >> .env
     # VOLUME CONFIGURATION
     # Don't change these.
-     - echo DATA_VOLUME=/sfm-data:/sfm-data
-     - echo PROCESSING_VOLUME=/sfm-processing:/sfm-processing
+     - echo DATA_VOLUME=/sfm-data:/sfm-data >> .env
+     - echo PROCESSING_VOLUME=/sfm-processing:/sfm-processing >> .env
     # SFM UI CONFIGURATION
     # Don't change this.
      - echo SFM_HOSTNAME=`curl http://169.254.169.254/latest/meta-data/public-hostname` >> .env


### PR DESCRIPTION
Edits cloud-config template so data & processing volumes are shared with the Docker Host (rather than echoing the instruction to do so into oblivion).

This makes sure the volume instruction (already present) is like all the other instructions being echoed to `.env`