### PR TITLE
Fixes #796 - Adds user account creation date to admin view

### DIFF
--- a/sfm/ui/admin.py
+++ b/sfm/ui/admin.py
@@ -38,7 +38,7 @@ class UserAdmin(AuthUserAdmin):
     fieldsets = AuthUserAdmin.fieldsets + (
         (None, {'fields': ('email_frequency', 'harvest_notifications',)}),
     )
-
+    list_display=['username','email','first_name','last_name','date_joined','is_staff']
 
 class Credential(a.ModelAdmin):
     fields = ('credential_id', 'user', 'platform', 'name', 'token', 'is_active', 'date_added',


### PR DESCRIPTION
Please click on "Users" link under the UI header in the Admin tab to see the changes.