### PR TITLE
Upgraded versions of most (but not all) Python packages

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,19 +1,19 @@
 APScheduler==3.5.1
 django==2.0.9
-django-allauth==0.36.0
+django-allauth==0.38.0
 django-braces==1.13.0
 django-crispy-forms==1.7.2
-django-simple-history==2.2.0
-djangorestframework==3.8.2
-django-filter==1.1.0
+django-datatables-view==1.17.0
 django-datetime-widget==0.9.3
-django-datatables-view==1.16.0
-iso8601==0.1.11
+django-filter==1.1.0
+django-simple-history==2.6.0
+djangorestframework==3.8.2
+iso8601==0.1.12
 jsonfield==2.0.2
-psycopg2-binary==2.7.5
-pytz==2018.5
+psycopg2-binary==2.7.6.1
+pytz==2018.7
 rabbitmq-admin==0.2
-SQLAlchemy==1.2.9
+SQLAlchemy==1.2.15
 # Used when executing SQL in migration.
 sqlparse==0.2.4
 
@@ -21,4 +21,4 @@ sqlparse==0.2.4
 requests==2.21.0
 
 # Testing
-mock==1.3.0
+mock==2.0.0


### PR DESCRIPTION
When testing this PR, also upgrade to the branches with the same name in:
- sfm-utils
- sfm-twitter-harvester
- sfm-flickr-harvester
- sfm-tumblr-harvester
- sfm-weibo-harvester

The following set of libraries was not upgraded due risk of and/or observation of potential problems that may require changes in SFM in order to upgrade:
- in sfm-ui:
   - APScheduler (currently 3.5.1, latest release is 3.5.3)
   - django-filter (currently 1.1.10, latest release is 2.0.0)
   - djangorestframework (currently 3.8.2, latest release is 3.9.0)
- in sfm-utils:
   - kombu (currently 4.0.2, latest release is 4.2.2)
- in sfm-flickr-harvester:
   - flickrapi (currently 2.1.1, latest release is 2.4.0)

These have been placed in #971 and #973.