### PR TITLE
Clarifying impacts of deadling with change in IP / Hostname of AWS

### DIFF
--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -4,7 +4,7 @@
 
 To make sure you have the best possible experience with SFM, you should be aware of the limitations and known issues:
 
-* Changes to the hostname of server (e.g., from the reboot of an AWS EC2 instance) are not handled (`Ticket 435 <https://github.com/gwu-libraries/sfm-ui/issues/435>`_)
+* Changes to the hostname of server (e.g., from the reboot of an AWS EC2 instance) are not handled (`Ticket 435 <https://github.com/gwu-libraries/sfm-ui/issues/435>`_) (see also `Troubleshooting <https://sfm.readthedocs.io/en/latest/troubleshooting.html>`_)
 
 For a complete list of tickets, see https://github.com/gwu-libraries/sfm-ui/issues
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -54,7 +54,7 @@ or choose a different port for SFM. (Chances are the other application is Apache
 Bad Request (400)
 ^^^^^^^^^^^^^^^^^
 If you receive a Bad Request (400) when trying to access SFM, your ``SFM_HOST`` environment variable is not
-configured correctly. For more information, see `ALLOWED_HOSTS <https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-ALLOWED_HOSTS>`_.
+configured correctly. Check what ``SFM_HOSTNAME`` is set to in *./home/ubuntu/.env*, and update and restart if necessary. For more information, see `ALLOWED_HOSTS <https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-ALLOWED_HOSTS>`_.
 
 Social Network Login Failure for Twitter
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I setup SFM on AWS and all was working well. Thanks for the great documentation - it made it really easy to setup and get going!

I foolishly tried to change the IP (ultimately to change the DNS / domain name to a custom one) and managed to mess up the web interface. I was struggling to find where to change the ALLOWED_HOSTS within Django. 

I discovered the place to change it was ./home/ubuntu/.env and have suggested an update to the documents below. Any comments etc. welcome!

Best wishes,
Nick.