### PR TITLE
fixes #905. Seed select box only shows for Selected Seeds export

### DIFF
--- a/sfm/ui/static/ui/css/main.css
+++ b/sfm/ui/static/ui/css/main.css
@@ -118,6 +118,7 @@ body {
 
 .longseed{
     word-wrap: break-word;
+    display: none;
 }
 
 table {

--- a/sfm/ui/static/ui/js/seed_select_option.js
+++ b/sfm/ui/static/ui/js/seed_select_option.js
@@ -1,0 +1,17 @@
+$(document).ready(function() {
+        // seed multiselect available only with "Selected seeds"
+        $("input#id_id_seed_choice_0_3").on("click", function () {
+          $(".longseed").show();
+        });
+	$("input#id_id_seed_choice_0_2").on("click", function() {
+          $(".longseed").hide();
+	});
+	$("input#id_id_seed_choice_0_1").on("click", function() {
+          $(".longseed").hide();
+        });
+        // show seed multiselect and error message if export page reloaded 
+	// because error in use of selection control 
+	if ( $("input#id_id_seed_choice_0_3:checked").length ) {
+	 $(".longseed").show();
+        }
+ });

--- a/sfm/ui/templates/base.html
+++ b/sfm/ui/templates/base.html
@@ -46,8 +46,9 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-multiselect/0.9.13/js/bootstrap-multiselect.min.js"></script>
 
     <script src="{% static 'ui/js/seed_multiselect.js' %}"></script>
+    <script src="{% static 'ui/js/seed_select_option.js' %}"></script>
 
-	{% block javascript %}
+    {% block javascript %}
 
     {% endblock %}
 


### PR DESCRIPTION
Test by going to the export page for a Twitter user timeline collection with more than one seed, and choose the Selected Seeds option. 