### PR TITLE
T1012 postgres upgrade

### DIFF
--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -1,6 +1,6 @@
-FROM postgres@sha256:a52a80868bfdd49f90d235a6800c4792f16bf0bd670bab814ad18fb8964a17c7
-#Postgres 9.4.5
-MAINTAINER Justin Littman <justinlittman@gwu.edu>
+FROM postgres:9.6
 
-ENV PGDATA /sfm-data/postgresql/data
+MAINTAINER Laura Wrubel <sfm@gwu.edu>
+
+ENV PGDATA /sfm-data/postgresql/9.6/data
 ADD initdb.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
Steps to set up and test:
1. Make a backup of the existing 9.4 database. In sfm-docker/:
`docker exec sfm_db_1 pg_dumpall -U postgres > pgdump`
Review it: 
`cat pgdump | less`
2. `docker-compose stop`
3.  `docker-compose rm -v db`
4. update docker-compose.yml to build the image for db.
```
    db: 
        build: 
            context: ../sfm-ui/docker/db 
            dockerfile: Dockerfile
       #image: gwul/sfm-ui-db:master
```
5. Create a postgres 9.6 database with just the default database, this triggers initdb running and creating a pg_hba.conf file with the correct permissions. Use the absolute path for your sfm-data/postgresql directory, this example uses mine:

```
docker run --name postgres -d -v /home/lwrubel/projects/sfm-data/postgresql/9.6/data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=password postgres:9.6
```
5. `docker stop postgres`
6. `docker rm -v postgres`
7. Run the upgrade image, changing the sfm-data path to match yours:
```
docker run --rm \
    -v /home/lwrubel/projects/sfm-data/postgresql/data:/var/lib/postgresql/9.4/data \
    -v /home/lwrubel/projects/sfm-data/postgresql/9.6/data:/var/lib/postgresql/9.6/data \
tianon/postgres-upgrade:9.4-to-9.6
```
8. Bring up the db container based on the new image:
`docker-compose up --build -d`



