### PR TITLE
Fixes #1009; adds configurable cookie consent popup

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -105,6 +105,12 @@ statements change *master* to the correct version, e.g., *2.2.0*::
     # - echo SFM_INSTITUTION_NAME=yourinstitution >> .env
     # Provide your institution link
     # - echo SFM_INSTITUTION_LINK=http://library.yourinstitution.edu >> .env
+    # Set to True to enable the cookie consent popup
+    # - echo SFM_ENABLE_COOKIE_CONSENT=False >> .env
+    # Provide the text you would like to appear on the cookie popup
+    # - echo SFM_COOKIE_CONSENT_HTML=<b>Do you like cookies?</b> &#x1F36A; We use cookies to ensure you get the best experience on our website. <a href="https://cookiesandyou.com/" target="_blank">Learn more</a> >> .env
+    # Provide the wording you would like to appear on the cookie button
+    # - echo SFM_COOKIE_CONSENT_BUTTON_TEXT=I consent >> .env
     # To send email, set these correctly.
     # - echo SFM_SMTP_HOST=smtp.gmail.com >> .env
     # - echo SFM_EMAIL_USER=someone@gmail.com >> .env
@@ -171,6 +177,13 @@ Configuration is documented in ``example.env``. For a production deployment, pay
 * Set an admin email address with ``SFM_SITE_ADMIN_EMAIL``. Problems with SFM are sent to this address.
 * Set an SFM contact email address with ``SFM_CONTACT_EMAIL``. Users are provided with this address.
 * For branding in the SFM UI, provide ``SFM_INSTITUTION_NAME`` and ``SFM_INSTITUTION_LINK``.
+* To enable the cookie consent popup:
+   * Set ``SFM_ENABLE_COOKIE_CONSENT`` to ``True``.
+   * Optionally, customize the text of ``SFM_COOKIE_CONSENT_HTML``.  HTML tags are allowed in
+     ``SFM_COOKIE_CONSENT_HTML``. For instance, you may wish to use an ``<a>`` (anchor tag) to 
+     include a link to your institution's privacy policy web page.
+   * Optionally, customize the wording of the cookie consent button in 
+     ``SFM_COOKIE_CONSENT_BUTTON_TEXT``.
 
 Note that if you make a change to configuration *after* SFM is brought up, you will need to restart containers. If
 the change only applies to a single container, then you can stop the container with ``docker kill <container name>``. If

--- a/sfm/sfm/settings/common.py
+++ b/sfm/sfm/settings/common.py
@@ -182,6 +182,11 @@ INSTITUTION_NAME = env.get('SFM_INSTITUTION_NAME')
 # a link for the institution name, such as 'http://library.gwu.edu'
 INSTITUTION_LINK = env.get('SFM_INSTITUTION_LINK')
 
+# Cookie popup html
+ENABLE_COOKIE_CONSENT = env.get('SFM_ENABLE_COOKIE_CONSENT') == 'True'
+COOKIE_CONSENT_HTML = env.get('SFM_COOKIE_CONSENT_HTML')
+COOKIE_CONSENT_BUTTON_TEXT = env.get('SFM_COOKIE_CONSENT_BUTTON_TEXT')
+
 # Directory where SFM data (e.g., harvested WARCs) is stored.
 SFM_DATA_DIR = env.get("SFM_DATA_DIR", "/sfm-data")
 

--- a/sfm/ui/context_processors.py
+++ b/sfm/ui/context_processors.py
@@ -2,6 +2,9 @@ from django.conf import settings as django_settings
 
 
 def settings(request):
-    # return the value you want as a dictionnary. you may add multiple values in there.
+    # return the value you want as a dictionary. you may add multiple values.
     return {'SFM_UI_VERSION': django_settings.SFM_UI_VERSION, 'CONTACT_EMAIL': django_settings.CONTACT_EMAIL,
-            'INSTITUTION_NAME': django_settings.INSTITUTION_NAME, 'INSTITUTION_LINK': django_settings.INSTITUTION_LINK}
+            'INSTITUTION_NAME': django_settings.INSTITUTION_NAME, 'INSTITUTION_LINK': django_settings.INSTITUTION_LINK,
+            'COOKIE_CONSENT_HTML': django_settings.COOKIE_CONSENT_HTML,
+            'COOKIE_CONSENT_BUTTON_TEXT': django_settings.COOKIE_CONSENT_BUTTON_TEXT,
+            'ENABLE_COOKIE_CONSENT': django_settings.ENABLE_COOKIE_CONSENT}

--- a/sfm/ui/static/ui/css/cookie_consent.css
+++ b/sfm/ui/static/ui/css/cookie_consent.css
@@ -1,0 +1,36 @@
+/*
+ * From https://cdn.jsdelivr.net/gh/Wruczek/Bootstrap-Cookie-Alert@gh-pages/cookiealert.css
+ * Bootstrap Cookie Alert by Wruczek
+ * https://github.com/Wruczek/Bootstrap-Cookie-Alert
+ * Released under MIT license
+ */
+.cookiealert {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    margin: 0 !important;
+    z-index: 999;
+    opacity: 0;
+    border-radius: 0;
+    transform: translateY(100%);
+    transition: all 500ms ease-out;
+    color: #ecf0f1;
+    background: #004065
+}
+
+.cookiealert.show {
+    opacity: 1;
+    transform: translateY(0%);
+    transition-delay: 1000ms;
+}
+
+.cookiealert a {
+    text-decoration: underline;
+    color: #00bbff
+}
+
+.cookiealert .acceptcookies {
+    margin-left: 10px;
+    vertical-align: baseline;
+}

--- a/sfm/ui/static/ui/js/cookie_consent.js
+++ b/sfm/ui/static/ui/js/cookie_consent.js
@@ -1,0 +1,58 @@
+$(document).ready(function() {
+
+// From https://cdn.jsdelivr.net/gh/Wruczek/Bootstrap-Cookie-Alert@gh-pages/cookiealert.js
+/*
+ * Bootstrap Cookie Alert by Wruczek
+ * https://github.com/Wruczek/Bootstrap-Cookie-Alert
+ * Released under MIT license
+ */
+(function () {
+    "use strict";
+
+    var cookieAlert = document.querySelector(".cookiealert");
+    var acceptCookies = document.querySelector(".acceptcookies");
+
+    if (!cookieAlert) {
+       return;
+    }
+
+    cookieAlert.offsetHeight; // Force browser to trigger reflow (https://stackoverflow.com/a/39451131)
+
+    // Show the alert if we cant find the "acceptCookies" cookie
+    if (!getCookie("acceptCookies")) {
+        cookieAlert.classList.add("show");
+    }
+
+    // When clicking on the agree button, create a 1 year
+    // cookie to remember user's choice and close the banner
+    acceptCookies.addEventListener("click", function () {
+        setCookie("acceptCookies", true, 365);
+        cookieAlert.classList.remove("show");
+    });
+
+    // Cookie functions from w3schools
+    function setCookie(cname, cvalue, exdays) {
+        var d = new Date();
+        d.setTime(d.getTime() + (exdays * 24 * 60 * 60 * 1000));
+        var expires = "expires=" + d.toUTCString();
+        document.cookie = cname + "=" + cvalue + ";" + expires + ";path=/";
+    }
+
+    function getCookie(cname) {
+        var name = cname + "=";
+        var decodedCookie = decodeURIComponent(document.cookie);
+        var ca = decodedCookie.split(';');
+        for (var i = 0; i < ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) === ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) === 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return "";
+    }
+})();
+
+});

--- a/sfm/ui/templates/base.html
+++ b/sfm/ui/templates/base.html
@@ -83,10 +83,10 @@
 
     {% if ENABLE_COOKIE_CONSENT %}
 
-      <div class="alert text-center cookiealert" role="alert">
-        <div class="container-fluid">
+      <div class="alert cookiealert" role="alert">
+        <div class="container">
           <div class="row align-items-center">
-            <!-- The "safe" filter is needed to disable automatic HTML escpaing;
+            <!-- The "safe" filter is needed to disable automatic HTML escaping;
                  this allows us to use HTML tags in the consent text,
                  for example to include an <a> tag for a link -->
             <div id="cookie_text" class="col-10">

--- a/sfm/ui/templates/base.html
+++ b/sfm/ui/templates/base.html
@@ -17,36 +17,38 @@
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
 
-  <!--Replacement for bootstrap-multiselect-->
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
+    <!--Replacement for bootstrap-multiselect-->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/css/bootstrap-select.min.css">
 
-	<!-- Your stuff: Third-party css libraries go here -->
+    <!-- Your stuff: Third-party css libraries go here -->
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700,600' rel='stylesheet' type='text/css'>
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.20/datatables.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/Wruczek/Bootstrap-Cookie-Alert@gh-pages/cookiealert.css">
 
-
-	<!-- This file store project specific CSS -->
+    <!-- SFM-specific CSS -->
     <link rel="stylesheet" href="{% static 'ui/css/main.css' %}">
+    <link rel="stylesheet" href="{% static 'ui/css/cookie_consent.css' %}">
 
     {% block css %}
 
     {% endblock %}
 
-	<!-- Latest JQuery -->
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
-  <!--Bootstrap 4 requires Popper.js-->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
-	<!-- Latest compiled and minified JavaScript -->
-	<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
-  <!-- datatables.js with Bootstrap 4 support -->
-  <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.20/datatables.min.js"></script>
-  <!--Font Awesome for icons-->
-  <script src="https://kit.fontawesome.com/012dee33a5.js" crossorigin="anonymous"></script>
+    <!-- Latest JQuery -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.3/jquery.min.js"></script>
+    <!--Bootstrap 4 requires Popper.js-->
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+    <!-- Latest compiled and minified JavaScript -->
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+    <!-- datatables.js with Bootstrap 4 support -->
+    <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.20/datatables.min.js"></script>
+    <!--Font Awesome for icons-->
+    <script src="https://kit.fontawesome.com/012dee33a5.js" crossorigin="anonymous"></script>
     <!-- multiselect javascript -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.9/dist/js/bootstrap-select.min.js"></script>
 
     <script src="{% static 'ui/js/seed_multiselect.js' %}"></script>
     <script src="{% static 'ui/js/seed_select_option.js' %}"></script>
+    <script src="{% static 'ui/js/cookie_consent.js' %}"></script>
 
     {% block javascript %}
 
@@ -54,9 +56,8 @@
 
     {% block extra_head %}
         <script src="https://cdn.datatables.net/1.10.15/js/jquery.dataTables.min.js"></script>
-        <!--<script src="https://cdn.datatables.net/1.10.15/js/dataTables.bootstrap.min.js"></script>-->
-		<script src="{% static 'ui/js/data_tables.js' %}"></script>
-		<script type="text/javascript">
+	<script src="{% static 'ui/js/data_tables.js' %}"></script>
+	<script type="text/javascript">
            var oPaginationType = "bs_normal";
            var oLanguages = {
                 "lengthMenu": "Display _MENU_ records per page",
@@ -71,21 +72,38 @@
             };
         </script>
     {% endblock %}
-
   </head>
 
   <body>
-    <!--<div class="navbar navbar-default">-->
+
+    {% if ENABLE_COOKIE_CONSENT %}
+
+      <div class="alert text-center cookiealert" role="alert">
+        <div class="container-fluid">
+          <div class="row align-items-center">
+            <!-- The "safe" filter is needed to disable automatic HTML escpaing;
+                 this allows us to use HTML tags in the consent text,
+                 for example to include an <a> tag for a link -->
+            <div id="cookie_text" class="col-10">
+              {{ COOKIE_CONSENT_HTML | safe }}
+            </div>
+            <div id="cookie_button" class="col-2">
+              <button type="button" class="btn btn-primary btn-sm acceptcookies" aria-label="Close">
+                {{ COOKIE_CONSENT_BUTTON_TEXT }}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+    {% endif %}
+
     <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm mb-3">  
       <div class="container-fluid">
         <!-- Brand and toggle get grouped for better mobile display -->
         <div class="navbar-header">
          <a class="navbar-brand" href="{% url 'home' %}">Social Feed Manager</a>
           <button type="button" class="navbar-toggler collapsed" data-toggle="collapse" data-target="#bs-navbar-collapse-1" aria-expanded="false">
-            <!--<span class="sr-only">Toggle navigation</span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>-->
             <span class="navbar-toggler-icon"></span>
           </button>
         </div>
@@ -162,6 +180,5 @@
             <strong><a href={{ INSTITUTION_LINK }} title="institution-name" target="_blank">{{ INSTITUTION_NAME }}</a></strong>
         </div>
     </footer>
-
 </body>
 </html>


### PR DESCRIPTION
To test:

- Set `sfm-docker` to branch https://github.com/gwu-libraries/sfm-docker/tree/t1009-cookie-consent-envvars (in PR https://github.com/gwu-libraries/sfm-docker/pull/26 )
- Change `SFM_ENABLE_COOKIE_CONSENT` to `True` in `.env` file.
- Customize `SFM_COOKIE_CONSENT_HTML` and `SFM_COOKIE_CONSENT_BUTTON_TEXT`.  Suggested values for GW:
```
SFM_ENABLE_COOKIE_CONSENT=True
SFM_COOKIE_CONSENT_HTML=GW uses cookies and other technology on our websites to improve your website experience and to better understand how you use our websites. Visit GW's <a href="https://www.gwu.edu/privacy-notice" target="_blank" aria-label="Website privacy notice, opens in new window">Website Privacy Notice</a> to learn more about how GW uses cookies and, if you should choose, how to disable them. I understand that by clicking "I consent" and continuing to use this website, I agree to GW's use of cookies.
SFM_COOKIE_CONSENT_BUTTON_TEXT=I consent
```
- View the application and verify that the popup appears.  Click "I Consent".
- Verify that upon viewing the application again in the same browser, the popup does not appear.
- Change `SFM_ENABLE_COOKIE_CONSENT` to `False` in `.env` file.
- Open application in an incognito window - or clear cookies.
- Stop and restart the UI docker container
- Verify that the cookie consent popup does not appear.
- Build the documentation and verify the changes to the `Installation and Configuration` page
