### PR TITLE
Fixes #1023; several accessibility improvements to base.html

### DIFF
--- a/sfm/ui/static/ui/css/cookie_consent.css
+++ b/sfm/ui/static/ui/css/cookie_consent.css
@@ -16,13 +16,15 @@
     transform: translateY(100%);
     transition: all 500ms ease-out;
     color: #ecf0f1;
-    background: #004065
+    background: #004065;
+    visibility: hidden
 }
 
 .cookiealert.show {
     opacity: 1;
     transform: translateY(0%);
     transition-delay: 1000ms;
+    visibility: visible
 }
 
 .cookiealert a {

--- a/sfm/ui/static/ui/css/main.css
+++ b/sfm/ui/static/ui/css/main.css
@@ -245,3 +245,18 @@ table {
 .card-title {
     margin-top: 8px;
 }
+
+#skiptocontent a, #skiptocontent a:hover, #skiptocontent a:visited {
+	position:absolute;
+	left:0px;
+	top:-500px;
+	width:1px;
+	height:1px;
+	overflow:hidden;
+}
+
+#skiptocontent a:active, #skiptocontent a:focus {
+	position:static;
+	width:auto;
+	height:auto;
+}

--- a/sfm/ui/templates/base.html
+++ b/sfm/ui/templates/base.html
@@ -52,7 +52,6 @@
 
     <!-- flatpickr for jQuery datetimepicker -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-    <!--<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>-->
     <script src="{% static 'ui/js/flatpickr.js' %}"></script>
 
     {% block javascript %}
@@ -93,7 +92,7 @@
               {{ COOKIE_CONSENT_HTML | safe }}
             </div>
             <div id="cookie_button" class="col-2">
-              <button type="button" class="btn btn-primary btn-sm acceptcookies" aria-label="Close">
+              <button type="button" class="btn btn-primary btn-sm acceptcookies">
                 {{ COOKIE_CONSENT_BUTTON_TEXT }}
               </button>
             </div>
@@ -102,6 +101,11 @@
       </div>
 
     {% endif %}
+
+    <!-- skip link -->
+    <div id="skiptocontent">
+      <a href="#maincontent">Skip to main content</a>
+    </div>
 
     <nav class="navbar navbar-expand-lg navbar-light bg-light shadow-sm mb-3">  
       <div class="container-fluid">
@@ -114,50 +118,59 @@
         </div>
           
         <!-- Collect the nav links, forms, and other content for toggling -->
-        <div class="collapse navbar-collapse" id="bs-navbar-collapse-1">
-          {% if request.user.is_authenticated %} 
+        {% if request.user.is_authenticated %}
+          <div class="collapse navbar-collapse" id="bs-navbar-collapse-1">
             <ul class="nav navbar-nav">
 	            <li class="nav-item"><a class="nav-link" href={% url "collection_set_list" %}>Collection Sets</a></li>
 	            <li class="nav-item"><a class="nav-link" href={% url "credential_list" %}>Credentials</a></li>
                 <li class="nav-item"><a class="nav-link" href={% url "export_list" %}>Exports</a></li>
                 <li class="nav-item"><a class="nav-link" href={% url "monitor" %}>Monitor</a></li>
             </ul>
-            {% endif %}
-         <ul class="nav navbar-nav ml-auto">
-             {% if request.user.is_authenticated %}
-             <li class="nav-item dropdown">
-               <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Welcome, {{ user.username }}<span class="caret"></span></a>
-               <ul class="dropdown-menu">
-                   {% if request.user.is_staff %}<li><a href="{% url 'admin:index' %}">Admin</a></li>{% endif %}
-                   <li class="dropdown-item"><a href="{% url 'user_profile_detail'%}">Your profile</a></li>
-                   <li class="dropdown-item"><a href="{% url 'account_change_password' %}">Change password</a></li>
-                   <li class="dropdown-item"><a href="{% url 'account_logout' %}">Log out</a></li>
-                 </ul>
-             </li>
-            {% endif %}
-          </ul>
-        </div>
+            <ul class="nav navbar-nav ml-auto">
+              <li class="nav-item dropdown">
+                <button type="button" class="btn dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Welcome, {{ user.username }}<span class="caret"></span></button>
+                <ul class="dropdown-menu">
+                  {% if request.user.is_staff %}<li><a href="{% url 'admin:index' %}">Admin</a></li>{% endif %}
+                  <li class="dropdown-item"><a href="{% url 'user_profile_detail'%}">Your profile</a></li>
+                  <li class="dropdown-item"><a href="{% url 'account_change_password' %}">Change password</a></li>
+                  <li class="dropdown-item"><a href="{% url 'account_logout' %}">Log out</a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        {% endif %}
       </div>
     </nav>
 
-    <div class="container sfm-container">
+    <main id="maincontent" class="container sfm-container">
       {% block content_header %}
       {% endblock content_header %}
       {% if messages %}
-          <div class="row">
-             <div class="col-md-12">
-                {% for message in messages %}
-                <div class="alert {% if message.tags %}alert-{{ message.tags }}"{% endif %}>{{ message }}</div>
-                {% endfor %} 
-             </div>
-          </div>
+         <div class="row">
+           <div class="col-md-12">
+              {% for message in messages %}
+                 {% if message.tags %}
+                   {% if message.tags == "error" %}
+                     <!-- django.contrib.messages uses "error" but bootstrap uses "danger" -->
+                     <div class="alert alert-danger" role="alert">
+                   {% else %}
+                     <div class="alert alert-{{ message.tags }}" role="status">
+                   {% endif %}
+                 {% else %}
+                   <div class="alert" role="status">
+                 {% endif %}
+                 {{ message }}</div>
+              {% endfor %}
+           </div>
+         </div>
       {% endif %}
       {% block content %}
         <p></p>
       {% endblock content %}
+    </main> <!-- /container -->
 
-    </div> <!-- /container -->
     {% block modal %}{% endblock modal %}
+
     <footer class="footer">
         <div class="footer-upper">
             <hr>


### PR DESCRIPTION
To test:

### Change sfm-container div to a main tag

Observe that main content is now in a `<main>` tag (previously a `<div>`)

### Change alerts to have a role of "status" not "alert" when yellow or green.

There seem to be few alerts that pass through the alert display code in `base.html` (rather than the alert display code within the body of other pages).  You can log out and get a green status alert that you have logged out, and you can log back in and get a green status alert that you logged back in.  In these cases, you can inspect the alert element and observe that it has a `role="status"` property.   If you know of some way to get an `error` alert on the main page, you can inspect that to confirm that the red alert box has `role="alert"`.

### Add skip navigation: hidden but focusable skip link at the top of the DOM that skips over the nav and breadcrumbs to the h1
_Note: I implemented this as to skip to the `<main>` block, which seems a more dependable choice than to the h1, as currently there is no h1 tag._

1.  Clear your browser's cookies OR open an incognito window.  When you first browse to the app and press <kbd>Tab</kbd>, focus should be in the cookie message text if there are links in the message text; the next focus should be the consent button.   Following this, hitting <kbd>Tab</kbd> again should unhide a `Skip to content` link in the upper left.  Pressing Enter on this link should result in the next focus being in the main body of the page - i.e. skipping the navigation bar.  The `Skip to content` link should then become hidden again.

2. Having already accepted the cookie consent in your browser, refresh the page. The first tab press on the page should un-hide the `Skip to content` link described above.

### User profile dropdown in nav bar should be instead of with role=button

Verify that the user profile dropdown in the upper right is implemented as a `<button>` tag, and that it has all the correct behaviors (the caret twists it open, the links work, etc.)