### PR TITLE
T1034 accessibility color

### DIFF
--- a/sfm/ui/static/ui/css/main.css
+++ b/sfm/ui/static/ui/css/main.css
@@ -16,7 +16,7 @@ h1 {
    margin-bottom: 1rem;
 }
 
-a {
+a, a.page-link {
     color: #2971a7;
 }
 
@@ -57,6 +57,10 @@ a:hover {
     border-color: #78BE20;
 }
 
+.btn-link i {
+    color: #2971a7;
+}
+
 .alert {
     margin-top: 10px;
 }
@@ -79,6 +83,10 @@ a:hover {
     color: #333;
 }
 
+.alert a {
+    text-decoration: underline;
+}
+
 .nav-link:hover {
     text-decoration: underline;
 }
@@ -89,6 +97,10 @@ a:hover {
 
 .breadcrumb {
     background-color: #ffffff;
+}
+
+.breadcrumb-item a {
+    text-decoration:underline;
 }
 
 .panel-on {
@@ -170,6 +182,9 @@ a:hover {
 }
 .modal {
     top: 35%;
+}
+.modal-body a {
+    text-decoration: underline;
 }
 
 .longseed{
@@ -273,4 +288,8 @@ p.harvest-type-display {
 	position:static;
 	width:auto;
 	height:auto;
+}
+
+td a {
+    text-decoration: underline;
 }

--- a/sfm/ui/static/ui/css/main.css
+++ b/sfm/ui/static/ui/css/main.css
@@ -31,7 +31,7 @@ a.btn {
 
 .btn-primary:active, .btn-primary:hover {
     background-color: #017ABC;
-    border-color: ##017ABC;
+    border-color: #017ABC;
     color: #FFF;
 }
 
@@ -42,8 +42,8 @@ a.btn {
 }
 
 .show>.btn-primary.dropdown-toggle:focus {
-    background-color: ##017ABC;
-    border-color: ##017ABC;
+    background-color: #017ABC;
+    border-color: #017ABC;
     color: #FFF;
 }
 

--- a/sfm/ui/static/ui/css/main.css
+++ b/sfm/ui/static/ui/css/main.css
@@ -36,8 +36,8 @@ a.btn {
 }
 
 .btn-primary:not(:disabled):not(.disabled):active {
-    background-color: ##017ABC;
-    border-color: ##017ABC;
+    background-color: #017ABC;
+    border-color: #017ABC;
     color: #FFF;
 }
 

--- a/sfm/ui/static/ui/css/main.css
+++ b/sfm/ui/static/ui/css/main.css
@@ -16,29 +16,34 @@ h1 {
    margin-bottom: 1rem;
 }
 
-a, a.page-link {
+a {
     color: #2971a7;
+    text-decoration: underline;
 }
 
 a:hover {
     color: #004065;
 }
 
+a.btn {
+    text-decoration: none;
+}
+
 .btn-primary:active, .btn-primary:hover {
-    background-color: #0190DB;
-    border-color: #0190DB;
+    background-color: #017ABC;
+    border-color: ##017ABC;
     color: #FFF;
 }
 
 .btn-primary:not(:disabled):not(.disabled):active {
-    background-color: #0190DB;
-    border-color: #0190DB;
-    color: #FFF; 
+    background-color: ##017ABC;
+    border-color: ##017ABC;
+    color: #FFF;
 }
 
 .show>.btn-primary.dropdown-toggle:focus {
-    background-color: #0190DB;
-    border-color: #0190DB;
+    background-color: ##017ABC;
+    border-color: ##017ABC;
     color: #FFF;
 }
 
@@ -83,24 +88,25 @@ a:hover {
     color: #333;
 }
 
-.alert a {
-    text-decoration: underline;
+.nav-link {
+    text-decoration: none;
 }
 
 .nav-link:hover {
     text-decoration: underline;
 }
 
+.navbar-header a {
+    text-decoration:none;
+}
+
 .navbar-light .navbar-nav .nav-link {
     color: #333;
+    text-decoration: none;
 }
 
 .breadcrumb {
     background-color: #ffffff;
-}
-
-.breadcrumb-item a {
-    text-decoration:underline;
 }
 
 .panel-on {
@@ -182,9 +188,6 @@ a:hover {
 }
 .modal {
     top: 35%;
-}
-.modal-body a {
-    text-decoration: underline;
 }
 
 .longseed{
@@ -288,8 +291,4 @@ p.harvest-type-display {
 	position:static;
 	width:auto;
 	height:auto;
-}
-
-td a {
-    text-decoration: underline;
 }

--- a/sfm/ui/templates/ui/collection_detail.html
+++ b/sfm/ui/templates/ui/collection_detail.html
@@ -67,7 +67,7 @@
                                 </label>
                                     <div class="controls ">
                                         <textarea class="textarea form-control" cols="40" id="id_history_note_off" name="history_note" rows="4"></textarea>
-                                        <p id="hint_id_history_note" class="help-block">Explain why you are turning off the collection.</p>
+                                        <p id="hint_id_history_note_off" class="help-block">Explain why you are turning off the collection.</p>
                                     </div>
                                 </div>
                             </div>
@@ -115,7 +115,7 @@
                                 </label>
                                     <div class="controls ">
                                         <textarea class="textarea form-control" cols="40" id="id_history_note_deactivate" name="history_note" rows="4"></textarea>
-                                        <p id="hint_id_history_note" class="help-block">Explain why you are deactivating the collection.</p>
+                                        <p id="hint_id_history_note_deactivate" class="help-block">Explain why you are deactivating the collection.</p>
                                     </div>
                                 </div>
                             </div>

--- a/sfm/ui/templates/ui/collection_set_detail.html
+++ b/sfm/ui/templates/ui/collection_set_detail.html
@@ -129,8 +129,7 @@ $(document).ready(function(){
                     {% for harvest_type, harvest_label in harvest_types %}
                         <li class="dropdown-item">
                             <a class="flex-column align-items" href="{% url "collection_create" collection_set.id harvest_type %}">
-                            <p><strong>Add {{ harvest_label }}</strong><br/>{{ harvest_description|get_item:harvest_type }}</p>
-                            </a>
+				    <p><strong>Add {{ harvest_label }}</strong></a><br/>{{ harvest_description|get_item:harvest_type }}</p>
                         </li>
                     {% endfor %}
                 </ul>

--- a/sfm/ui/templates/ui/collection_set_detail.html
+++ b/sfm/ui/templates/ui/collection_set_detail.html
@@ -104,7 +104,7 @@ $(document).ready(function(){
                 </button>
                 <button type="button" class="btn btn-link" data-toggle="modal" data-target="#collectionsModal" aria-label="Details about each collection type">
                   <!--<a href="#collectionsModal" data-toggle="modal" role="button" >-->
-                    <i class="fas fa-info-circle" style="padding-top:7px; margin-left: 10px" aria-hidden="true"></i>
+                    <i class="fas fa-info-circle fa-lg" style="padding-top:7px; margin-left: 5px" aria-hidden="true"></i>
                     <!--</a>-->
                   </button>
 

--- a/sfm/ui/views.py
+++ b/sfm/ui/views.py
@@ -223,11 +223,11 @@ class SeedsJSONAPIView(LoginRequiredMixin, BaseDatatableView):
         elif column == 'messages':
             msg_seed = ""
             for msg in self.seed_infos.get(row.seed_id, []):
-                msg_seed += u'<li><p class="text-info">{}</p></li>'.format(msg)
+                msg_seed += u'<li><p>{}</p></li>'.format(msg)
             for msg in self.seed_warnings.get(row.seed_id, []):
-                msg_seed += u'<li><p class="text-warning">{}</p></li>'.format(msg)
+                msg_seed += u'<li><p>{}</p></li>'.format(msg)
             for msg in self.seed_errors.get(row.seed_id, []):
-                msg_seed += u'<li><p class="text-danger">{}</p></li>'.format(msg)
+                msg_seed += u'<li><p>{}</p></li>'.format(msg)
             return mark_safe(u'<ul>{}</ul>'.format(msg_seed)) if msg_seed else ""
 
         elif column == 'uid':


### PR DESCRIPTION
Review that links are underlined by default, with exceptions for navigation and buttons. The button color on hover/active should now have acceptable contrast with the white text on it. I've added unique id properties to the various links to add a history note. 

I left the footer links underlined, since that will be superseded in the application of the footer update in #1003. 