### PR TITLE
Docs about moving sfm-data to separate volume: Postgres and RabbitMQ user ID is 999

### DIFF
--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -108,6 +108,9 @@ These instructions are for Ubuntu. They may need to be adjusted for other operat
 
         sudo chown -R 990:990 /sfm-data/*
         
+        sudo chown -R 999:999 /sfm-data/postgresql/
+        sudo chown -R 999:999 /sfm-data/rabbitmq/
+
 4. Change .env::
 
         #DATA_VOLUME=/sfm-data


### PR DESCRIPTION
In case, sfm data is moved out from the container to a linked volume and sfm was already in use:
the user ID of PostgreSQL and RabbitMQ users is 999 (defined in the Docker containers/images). The ownership of the subfolders needs to be set accordingly. Otherwise the "db" and "mq" services will not work with the linked data volume.