### PR TITLE
Replace sfm-data with more fine grained sfm-*-data

### DIFF
--- a/docker/consumer/invoke_consumer.sh
+++ b/docker/consumer/invoke_consumer.sh
@@ -2,7 +2,7 @@
 set -e
 
 sh /opt/sfm-setup/setup_reqs.sh
-appdeps.py --wait-secs 90 --port-wait db:5432 --file /opt/sfm-ui --port-wait mq:5672 --port-wait ui:8080 --file-wait /sfm-data/collection_set
+appdeps.py --wait-secs 90 --port-wait db:5432 --file /opt/sfm-ui --port-wait mq:5672 --port-wait ui:8080 --file-wait /sfm-collection-set-data/collection_set
 
 echo "Running consumer"
 exec gosu sfm /opt/sfm-ui/sfm/manage.py startconsumer

--- a/docker/db/Dockerfile
+++ b/docker/db/Dockerfile
@@ -2,5 +2,5 @@ FROM postgres:9.6
 
 MAINTAINER Laura Wrubel <sfm@gwu.edu>
 
-ENV PGDATA /sfm-data/postgresql/9.6/data
+ENV PGDATA /sfm-db-data/postgresql/9.6/data
 ADD initdb.sql /docker-entrypoint-initdb.d/

--- a/docker/ui/invoke.sh
+++ b/docker/ui/invoke.sh
@@ -2,7 +2,7 @@
 set -e
 
 sh /opt/sfm-setup/setup_reqs.sh
-appdeps.py --wait-secs 60 --port-wait db:5432 --file /opt/sfm-ui --port-wait mq:5672  --file-wait /sfm-data/collection_set
+appdeps.py --wait-secs 60 --port-wait db:5432 --file /opt/sfm-ui --port-wait mq:5672  --file-wait /sfm-collection-set-data/collection_set
 sh /opt/sfm-setup/setup_ui.sh
 
 echo "Running server"

--- a/docker/ui/invoke_runserver.sh
+++ b/docker/ui/invoke_runserver.sh
@@ -2,7 +2,7 @@
 set -e
 
 sh /opt/sfm-setup/setup_reqs.sh
-appdeps.py --wait-secs 60 --port-wait db:5432 --file /opt/sfm-ui --port-wait mq:5672 --file-wait /sfm-data/collection_set
+appdeps.py --wait-secs 60 --port-wait db:5432 --file /opt/sfm-ui --port-wait mq:5672 --file-wait /sfm-collection-set-data/collection_set
 sh /opt/sfm-setup/setup_ui.sh
 
 echo "Running server"

--- a/sfm/sfm/settings/common.py
+++ b/sfm/sfm/settings/common.py
@@ -190,8 +190,12 @@ COOKIE_CONSENT_BUTTON_TEXT = env.get('SFM_COOKIE_CONSENT_BUTTON_TEXT')
 # GW footer
 ENABLE_GW_FOOTER = env.get('SFM_ENABLE_GW_FOOTER') == 'True'
 
-# Directory where SFM data (e.g., harvested WARCs) is stored.
-SFM_DATA_DIR = env.get("SFM_DATA_DIR", "/sfm-data")
+# Directories where SFM data (e.g., harvested WARCs) is stored.
+SFM_COLLECTION_SET_DATA_DIR = env.get("SFM_COLLECTION_SET_DATA_DIR", "/sfm-collection-set-data")
+SFM_DB_DATA_DIR = env.get("SFM_DB_DATA_DIR", "/sfm-db-data")
+SFM_EXPORT_DATA_DIR = env.get("SFM_EXPORT_DATA_DIR", "/sfm-export-data")
+SFM_MQ_DATA_DIR = env.get("SFM_MQ_DATA_DIR", "/sfm-mq-data")
+SFM_CONTAINERS_DATA_DIR = env.get("SFM_CONTAINERS_DATA_DIR", "/sfm-containers-data")
 
 # Directory where SFM processing data is stored.
 SFM_PROCESSING_DIR = env.get("SFM_PROCESSING_DIR", "/sfm-processing")
@@ -231,15 +235,19 @@ PERFORM_USER_HARVEST_EMAILS = env.get('SFM_PERFORM_USER_HARVEST_EMAILS', 'True')
 USER_HARVEST_EMAILS_HOUR = env.get('SFM_USER_HARVEST_EMAILS_HOUR', '1')
 USER_HARVEST_EMAILS_MINUTE = env.get('SFM_USER_HARVEST_EMAILS_MINUTE', '0')
 
-# Whether to scan the amount of free space on /sfm-data and /sfm-processing
+# Whether to scan the amount of free space on /sfm-db-data, /sfm-mq-data, /sfm-export-data, /sfm-containers-data, /sfm-collection-set-data and /sfm-processing
 PERFORM_SCAN_FREE_SPACE = env.get('SFM_PERFORM_SCAN_FREE_SPACE', 'True') == 'True'
 SCAN_FREE_SPACE_HOUR_INTERVAL = env.get('SFM_SCAN_FREE_SPACE_HOUR_INTERVAL', '12')
 # sfm data space threshold to send notification email,only ends with MB,GB,TB. eg. 500MB,10GB,1TB
-DATA_THRESHOLD = env.get('DATA_VOLUME_THRESHOLD', '10GB')
+DATA_THRESHOLD_DB = env.get('DATA_VOLUME_THRESHOLD_DB', '10GB')
+DATA_THRESHOLD_MQ = env.get('DATA_VOLUME_THRESHOLD_MQ', '10GB')
+DATA_THRESHOLD_EXPORT = env.get('DATA_VOLUME_THRESHOLD_EXPORT', '10GB')
+DATA_THRESHOLD_CONTAINERS = env.get('DATA_VOLUME_THRESHOLD_CONTAINERS', '10GB')
+DATA_THRESHOLD_COLLECTION_SET = env.get('DATA_VOLUME_THRESHOLD_COLLECTION_SET', '10GB')
 # sfm processing space threshold to send notification email,only ends with MB,GB,TB. eg. 500MB,10GB,1TB
 PROCESSING_THRESHOLD = env.get('PROCESSING_VOLUME_THRESHOLD', '10GB')
 
-# Whether to scan the amount of free space on /sfm-data and /sfm-processing
+# Whether to scan the amount of free space on /sfm-db-data, /sfm-mq-data, /sfm-export-data, /sfm-containers-data, /sfm-collection-set-data and /sfm-processing
 PERFORM_MONITOR_QUEUE = env.get('SFM_PERFORM_MONITOR_QUEUE', 'True') == 'True'
 # frequency to check the queue message length,default is 2 hour
 MONITOR_QUEUE_HOUR_INTERVAL = env.get('SFM_MONITOR_QUEUE_HOUR_INTERVAL', '12')

--- a/sfm/sfm/settings/test_settings.py
+++ b/sfm/sfm/settings/test_settings.py
@@ -10,7 +10,11 @@ DATABASES = {
     }
 }
 
-SFM_DATA_DIR = os.path.join(tempfile.gettempdir(), "test-data")
+SFM_DB_DATA_DIR = os.path.join(tempfile.gettempdir(), "test-data")
+SFM_MQ_DATA_DIR = os.path.join(tempfile.gettempdir(), "test-data")
+SFM_EXPORT_DATA_DIR = os.path.join(tempfile.gettempdir(), "test-data")
+SFM_CONTAINERS_DATA_DIR = os.path.join(tempfile.gettempdir(), "test-data")
+SFM_COLLECTION_SET_DATA_DIR = os.path.join(tempfile.gettempdir(), "test-data")
 
 SCHEDULER_DB_URL = "sqlite:///testdb"
 

--- a/sfm/ui/management/commands/deserializecollection.py
+++ b/sfm/ui/management/commands/deserializecollection.py
@@ -8,12 +8,12 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("collection_path",
                             help="The path of the collection to be imported. The path should be a subdirectory of "
-                                 "a collection set within /sfm-data/collection_set")
+                                 "a collection set within /sfm-collection-set-data/collection_set")
 
     def handle(self, *args, **options):
-        if not options["collection_path"].startswith("/sfm-data/collection_set"):
+        if not options["collection_path"].startswith("/sfm-collection-set-data/collection_set"):
             raise CommandError("Collection path should be a subdirectory of a collection set within "
-                               "/sfm-data/collection_set")
+                               "/sfm-collection-set-data/collection_set")
         self.stdout.write("Deserializing")
         serializer = RecordDeserializer()
         serializer.deserialize_collection(options["collection_path"])

--- a/sfm/ui/management/commands/deserializecollectionset.py
+++ b/sfm/ui/management/commands/deserializecollectionset.py
@@ -8,11 +8,11 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument("collection_set_path",
                             help="The path of the collection set to be imported. The path should be a subdirectory of "
-                                 "/sfm-data/collection_set")
+                                 "/sfm-collection-set-data/collection_set")
 
     def handle(self, *args, **options):
-        if not options["collection_set_path"].startswith("/sfm-data/collection_set"):
-            raise CommandError("Collection set path should be a subdirectory of /sfm-data/collection_set")
+        if not options["collection_set_path"].startswith("/sfm-collection-set-data/collection_set"):
+            raise CommandError("Collection set path should be a subdirectory of /sfm-collection-set-data/collection_set")
         self.stdout.write("Deserializing")
         serializer = RecordDeserializer()
         serializer.deserialize_collection_set(options["collection_set_path"])

--- a/sfm/ui/models.py
+++ b/sfm/ui/models.py
@@ -813,7 +813,7 @@ class Export(models.Model):
     instance = models.CharField(max_length=255, null=True)
 
     def save(self, *args, **kwargs):
-        self.path = "{}/export/{}".format(settings.SFM_DATA_DIR, self.export_id)
+        self.path = "{}/export/{}".format(settings.SFM_EXPORT_DATA_DIR, self.export_id)
         super(Export, self).save(*args, **kwargs)
 
     def __str__(self):

--- a/sfm/ui/notifications.py
+++ b/sfm/ui/notifications.py
@@ -48,6 +48,7 @@ class MonitorSpace(object):
             # the sfm-data and sfm-processing mount at sfm-data,
             # we only need to count the sfm-data
             if line_units:
+                # The following uncommented code will not work anymore, '/sfm-data' was removed and replaced by '/sfm-db-data', '/sfm-mq-data' etc
                 # get rid of the unit at the space,12M
                 # eg:['/dev/sda1', '208074M', '47203M', '150279M', '24%', '/sfm-data']
                 total_free_space = int(line_units[3][:-1])
@@ -127,9 +128,19 @@ def get_free_space():
     :return: a space data list
     """
     data_list = []
-    # get sfm-data info
-    data_monitor = MonitorSpace(settings.SFM_DATA_DIR, settings.DATA_THRESHOLD)
-    data_list.append(data_monitor.get_space_info())
+    # get data directories info (sfm-db-data, sfm-mq-data, sfm-export-data, sfm-containers-data and sfm-collection-set-data)
+    data_db_monitor = MonitorSpace(settings.SFM_DB_DATA_DIR, settings.DATA_THRESHOLD_DB)
+    data_mq_monitor = MonitorSpace(settings.SFM_MQ_DATA_DIR, settings.DATA_THRESHOLD_MQ)
+    data_export_monitor = MonitorSpace(settings.SFM_EXPORT_DATA_DIR, settings.DATA_THRESHOLD_EXPORT)
+    data_containers_monitor = MonitorSpace(settings.SFM_CONTAINERS_DATA_DIR, settings.DATA_THRESHOLD_CONTAINERS)
+    data_collection_set_monitor = MonitorSpace(settings.SFM_COLLECTION_SET_DATA_DIR, settings.DATA_THRESHOLD_COLLECTION_SET)
+
+    data_list.append(data_db_monitor.get_space_info())
+    data_list.append(data_mq_monitor.get_space_info())
+    data_list.append(data_export_monitor.get_space_info())
+    data_list.append(data_containers_monitor.get_space_info())
+    data_list.append(data_collection_set_monitor.get_space_info())
+
     # get sfm-processing info
     processing_monitor = MonitorSpace(settings.SFM_PROCESSING_DIR, settings.PROCESSING_THRESHOLD)
     data_list.append(processing_monitor.get_space_info())

--- a/sfm/ui/test_jobs.py
+++ b/sfm/ui/test_jobs.py
@@ -41,7 +41,7 @@ class StartJobsTests(TestCase):
         self.assertTrue(message["collection_set"]["id"])
         self.assertTrue(message["collection"]["id"])
         self.assertEqual(
-            "{}/collection_set/{}/{}".format(settings.SFM_DATA_DIR, self.collection_set.collection_set_id,
+            "{}/collection_set/{}/{}".format(settings.SFM_COLLECTION_SET_DATA_DIR, self.collection_set.collection_set_id,
                                              collection.collection_id),
             message["path"])
         self.assertDictEqual(self.harvest_options, message["options"])
@@ -103,7 +103,7 @@ class StartJobsTests(TestCase):
         message = args[0]
         self.assertTrue(message["collection_set"]["id"])
         self.assertEqual(
-            "{}/collection_set/{}/{}".format(settings.SFM_DATA_DIR, self.collection_set.collection_set_id,
+            "{}/collection_set/{}/{}".format(settings.SFM_COLLECTION_SET_DATA_DIR, self.collection_set.collection_set_id,
                                              collection.collection_id),
             message["path"])
         self.assertDictEqual(self.harvest_options, message["options"])

--- a/sfm/ui/test_notifications.py
+++ b/sfm/ui/test_notifications.py
@@ -316,9 +316,9 @@ class SpaceNotificationTests(TestCase):
         self.user_no_email = User.objects.create_user(username="test_user3")
 
     @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
-    def test_get_free_info(self, mock_run_cmd):
-        mock_run_cmd.side_effect = ['/dev/sda1        204800M 50949M   102400M  50% /sfm-data']
-        data_monitor = MonitorSpace('/sfm-data', '200GB')
+    def test_get_free_info_db(self, mock_run_cmd):
+        mock_run_cmd.side_effect = ['/dev/sda1        204800M 50949M   102400M  50% /sfm-db-data']
+        data_monitor = MonitorSpace('/sfm-db-data', '200GB')
         space_msg_cache = {'space_data': data_monitor.get_space_info()}
         self.assertEqual('200.0GB', space_msg_cache['space_data']['total_space'])
         self.assertEqual('100.0GB', space_msg_cache['space_data']['total_free_space'])
@@ -326,27 +326,111 @@ class SpaceNotificationTests(TestCase):
         self.assertTrue(space_msg_cache['space_data']['send_email'])
 
     @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
-    def test_get_free_info_empty(self, mock_run_cmd):
+    def test_get_free_info_mq(self, mock_run_cmd):
+        mock_run_cmd.side_effect = ['/dev/sda1        204800M 50949M   102400M  50% /sfm-mq-data']
+        data_monitor = MonitorSpace('/sfm-mq-data', '200GB')
+        space_msg_cache = {'space_data': data_monitor.get_space_info()}
+        self.assertEqual('200.0GB', space_msg_cache['space_data']['total_space'])
+        self.assertEqual('100.0GB', space_msg_cache['space_data']['total_free_space'])
+        self.assertEqual(50, space_msg_cache['space_data']['percentage'])
+        self.assertTrue(space_msg_cache['space_data']['send_email'])
+
+    @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
+    def test_get_free_info_export(self, mock_run_cmd):
+        mock_run_cmd.side_effect = ['/dev/sda1        204800M 50949M   102400M  50% /sfm-export-data']
+        data_monitor = MonitorSpace('/sfm-export-data', '200GB')
+        space_msg_cache = {'space_data': data_monitor.get_space_info()}
+        self.assertEqual('200.0GB', space_msg_cache['space_data']['total_space'])
+        self.assertEqual('100.0GB', space_msg_cache['space_data']['total_free_space'])
+        self.assertEqual(50, space_msg_cache['space_data']['percentage'])
+        self.assertTrue(space_msg_cache['space_data']['send_email'])
+
+    @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
+    def test_get_free_info_containers(self, mock_run_cmd):
+        mock_run_cmd.side_effect = ['/dev/sda1        204800M 50949M   102400M  50% /sfm-containers-data']
+        data_monitor = MonitorSpace('/sfm-containers-data', '200GB')
+        space_msg_cache = {'space_data': data_monitor.get_space_info()}
+        self.assertEqual('200.0GB', space_msg_cache['space_data']['total_space'])
+        self.assertEqual('100.0GB', space_msg_cache['space_data']['total_free_space'])
+        self.assertEqual(50, space_msg_cache['space_data']['percentage'])
+        self.assertTrue(space_msg_cache['space_data']['send_email'])
+
+    @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
+    def test_get_free_info_collection_set(self, mock_run_cmd):
+        mock_run_cmd.side_effect = ['/dev/sda1        204800M 50949M   102400M  50% /sfm-collection-set-data']
+        data_monitor = MonitorSpace('/sfm-collection-set-data', '200GB')
+        space_msg_cache = {'space_data': data_monitor.get_space_info()}
+        self.assertEqual('200.0GB', space_msg_cache['space_data']['total_space'])
+        self.assertEqual('100.0GB', space_msg_cache['space_data']['total_free_space'])
+        self.assertEqual(50, space_msg_cache['space_data']['percentage'])
+        self.assertTrue(space_msg_cache['space_data']['send_email'])
+
+
+
+    @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
+    def test_get_free_info_empty_db(self, mock_run_cmd):
         mock_run_cmd.side_effect = ['']
-        data_monitor = MonitorSpace('/sfm-data', '200GB')
+        data_monitor = MonitorSpace('/sfm-db-data', '200GB')
         space_msg_cache = {'space_data': data_monitor.get_space_info()}
         self.assertEqual('0.0MB', space_msg_cache['space_data']['total_space'])
         self.assertEqual('0.0MB', space_msg_cache['space_data']['total_free_space'])
         self.assertEqual(0, space_msg_cache['space_data']['percentage'])
         self.assertFalse(space_msg_cache['space_data']['send_email'])
 
+    @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
+    def test_get_free_info_empty_mq(self, mock_run_cmd):
+        mock_run_cmd.side_effect = ['']
+        data_monitor = MonitorSpace('/sfm-mq-data', '200GB')
+        space_msg_cache = {'space_data': data_monitor.get_space_info()}
+        self.assertEqual('0.0MB', space_msg_cache['space_data']['total_space'])
+        self.assertEqual('0.0MB', space_msg_cache['space_data']['total_free_space'])
+        self.assertEqual(0, space_msg_cache['space_data']['percentage'])
+        self.assertFalse(space_msg_cache['space_data']['send_email'])
+
+    @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
+    def test_get_free_info_empty_export(self, mock_run_cmd):
+        mock_run_cmd.side_effect = ['']
+        data_monitor = MonitorSpace('/sfm-export-data', '200GB')
+        space_msg_cache = {'space_data': data_monitor.get_space_info()}
+        self.assertEqual('0.0MB', space_msg_cache['space_data']['total_space'])
+        self.assertEqual('0.0MB', space_msg_cache['space_data']['total_free_space'])
+        self.assertEqual(0, space_msg_cache['space_data']['percentage'])
+        self.assertFalse(space_msg_cache['space_data']['send_email'])
+
+    @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
+    def test_get_free_info_empty_containers(self, mock_run_cmd):
+        mock_run_cmd.side_effect = ['']
+        data_monitor = MonitorSpace('/sfm-containers-data', '200GB')
+        space_msg_cache = {'space_data': data_monitor.get_space_info()}
+        self.assertEqual('0.0MB', space_msg_cache['space_data']['total_space'])
+        self.assertEqual('0.0MB', space_msg_cache['space_data']['total_free_space'])
+        self.assertEqual(0, space_msg_cache['space_data']['percentage'])
+        self.assertFalse(space_msg_cache['space_data']['send_email'])
+
+    @patch("ui.notifications.MonitorSpace.run_check_cmd", autospec=True)
+    def test_get_free_info_empty_collection_set(self, mock_run_cmd):
+        mock_run_cmd.side_effect = ['']
+        data_monitor = MonitorSpace('/sfm-collection-set-data', '200GB')
+        space_msg_cache = {'space_data': data_monitor.get_space_info()}
+        self.assertEqual('0.0MB', space_msg_cache['space_data']['total_space'])
+        self.assertEqual('0.0MB', space_msg_cache['space_data']['total_free_space'])
+        self.assertEqual(0, space_msg_cache['space_data']['percentage'])
+        self.assertFalse(space_msg_cache['space_data']['send_email'])
+
+
     def test_should_send_space_email_space_below(self):
         msg_cache = {
-            'space_data': [{'volume_id': '/sfm-data', 'threshold': '200GB', 'bar_color': 'progress-bar-success',
+            'space_data': [{'volume_id': '/sfm-db-data', 'threshold': '200GB', 'bar_color': 'progress-bar-success',
                             'total_space': '200GB', 'total_free_space': '100GB', 'percentage': 50, 'send_email': True},
                            {'volume_id': '/sfm-processing', 'threshold': '200GB', 'bar_color': 'progress-bar-success',
                             'total_space': '0.0MB', 'total_free_space': '0.0MB', 'percentage': 0, 'send_email': False}]
         }
         self.assertTrue(_should_send_space_email(msg_cache))
 
+
     def test_should_send_space_email_space_over(self):
         msg_cache = {
-            'space_data': [{'volume_id': '/sfm-data', 'threshold': '50GB', 'bar_color': 'progress-bar-success',
+            'space_data': [{'volume_id': '/sfm-db-data', 'threshold': '50GB', 'bar_color': 'progress-bar-success',
                             'total_space': '200GB', 'total_free_space': '100GB', 'percentage': 50, 'send_email': False},
                            {'volume_id': '/sfm-processing', 'threshold': '200GB', 'bar_color': 'progress-bar-success',
                             'total_space': '0.0MB', 'total_free_space': '0.0MB', 'percentage': 0, 'send_email': False}]

--- a/sfm/ui/test_views.py
+++ b/sfm/ui/test_views.py
@@ -344,8 +344,8 @@ class ExportDetailViewTests(TestCase):
             f.write("test")
 
     def tearDown(self):
-        if os.path.exists(settings.SFM_DATA_DIR):
-            shutil.rmtree(settings.SFM_DATA_DIR)
+        if os.path.exists(settings.SFM_COLLECTION_SET_DATA_DIR):
+            shutil.rmtree(settings.SFM_COLLECTION_SET_DATA_DIR)
 
     def test_export_detail_collection(self):
         export = Export.objects.create(user=self.user,
@@ -421,8 +421,8 @@ class ExportFileTest(TestCase):
         self.factory = RequestFactory()
 
     def tearDown(self):
-        if os.path.exists(settings.SFM_DATA_DIR):
-            shutil.rmtree(settings.SFM_DATA_DIR)
+        if os.path.exists(settings.SFM_COLLECTION_SET_DATA_DIR):
+            shutil.rmtree(settings.SFM_COLLECTION_SET_DATA_DIR)
 
     def test_export_file_by_user(self):
         request = self.factory.get(reverse("export_file", args=[self.export.pk, "test.csv"]))

--- a/sfm/ui/utils.py
+++ b/sfm/ui/utils.py
@@ -181,7 +181,7 @@ def collection_path(collection, sfm_data_dir=None):
 
 
 def collection_path_by_id(collection_set_id, collection_id, sfm_data_dir=None):
-    return os.path.join(sfm_data_dir or settings.SFM_DATA_DIR, "collection_set",
+    return os.path.join(sfm_data_dir or settings.SFM_COLLECTION_SET_DATA_DIR, "collection_set",
                         collection_set_id,
                         collection_id)
 
@@ -191,7 +191,7 @@ def collection_set_path(collection_set, sfm_data_dir=None):
 
 
 def collection_set_path_by_id(collection_set_id, sfm_data_dir=None):
-    return os.path.join(sfm_data_dir or settings.SFM_DATA_DIR, "collection_set", collection_set_id)
+    return os.path.join(sfm_data_dir or settings.SFM_COLLECTION_SET_DATA_DIR, "collection_set", collection_set_id)
 
 
 def get_email_addresses_for_collection_set(collection_set, use_harvest_notification_preference=False,


### PR DESCRIPTION
As discussed in issue https://github.com/gwu-libraries/sfm-ui/issues/1051 this PR adapts the internal folder structure of SFM to use the following directories instead of the single directory `/sfm-data`: `/sfm-db-data`, `/sfm-mq-data`, `/sfm-export-data`, `/sfm-containers-data`, `/sfm-collection-set-data`.

Merge conflicts will arise in conjunction with PR https://github.com/gwu-libraries/sfm-ui/pull/1050 as a single line in `invoke` scripts are changed by both PRs, namely `invoke.sh`, `invoke_consumer.sh`, and `invoke_runserver.sh`.

Solution: adapt respective lines to use both `/sfm-collection-set-data/collection-set` and variables for services and ports from https://github.com/gwu-libraries/sfm-ui/pull/1050
