### PR TITLE
Fix off-by-one error in join_stats

### DIFF
--- a/sfm/ui/templatetags/ui_extras.py
+++ b/sfm/ui/templatetags/ui_extras.py
@@ -144,7 +144,7 @@ def join_stats(d, status, sep=", "):
 
     if d:
         for i, (item, count) in enumerate(d.items()):
-            if i > 1:
+            if i > 0:
                 joined += sep
             joined += "{} {}".format(intcomma(count), item)
     return joined if joined else empty_extras


### PR DESCRIPTION
in order to join the first two elements using the given separator.

If there are two or more item types to be shown in the "Stats" column (monitor, collection and harvest details), the first two appear glued together without any separator, eg. "1 image1 post".