### PR TITLE
Write README.txt also for collections set with no collections

### DIFF
--- a/sfm/ui/serialize.py
+++ b/sfm/ui/serialize.py
@@ -54,9 +54,15 @@ class RecordSerializer:
         for collection in collection_set.collections.all():
             self.serialize_collection(collection, force_serialize=force_serialize)
 
+        cspath = get_collection_set_path(collection_set, sfm_data_dir=self.data_dir)
+
+        # create collection set folder if it does not exist
+        # (no collection yet created in the collection set)
+        if not os.path.exists(cspath):
+            os.makedirs(cspath)
+
         # README
-        self._write_readme("collection_set", collection_set,
-                           get_collection_set_path(collection_set, sfm_data_dir=self.data_dir))
+        self._write_readme("collection_set", collection_set, cspath)
 
     def serialize_collection(self, collection, force_serialize=False):
         records_path = os.path.join(get_collection_path(collection, sfm_data_dir=self.data_dir), RECORD_DIR)


### PR DESCRIPTION
Prevent `serialize_all` from failing on an empty collection set when writing the README.txt:
```
INFO 2022-03-04 03:00:54,182 63 ui.serialize Serializing <Collection Set 72 "...">
ERROR 2022-03-04 03:00:54,186 63 apscheduler.executors.default Job "serialize_all (trigger: cron[hour='3', minute='0'], next run at: 2022-03-05 03:00:00 UTC)" raised an exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
  File "/opt/sfm-ui/sfm/ui/serialize.py", line 550, in serialize_all
    serializer.serialize_all()
  File "/opt/sfm-ui/sfm/ui/serialize.py", line 50, in serialize_all
    self.serialize_collection_set(collection_set, force_serialize=force_serialize)
  File "/opt/sfm-ui/sfm/ui/serialize.py", line 59, in serialize_collection_set
    get_collection_set_path(collection_set, sfm_data_dir=self.data_dir))
  File "/opt/sfm-ui/sfm/ui/serialize.py", line 271, in _write_readme
    with codecs.open(readme_filepath, "w", encoding="utf-8") as f:
  File "/usr/local/lib/python3.6/codecs.py", line 897, in open
    file = builtins.open(filename, mode, buffering)
No such file or directory: '/sfm-data/collection_set/aa0cbd1e5c374c0a9c67cf2ce45caf9b/README.txt'
```