### PR TITLE
T1104 v2 filter stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@
 FROM gwul/sfm-base@sha256:0b80a3d3562cdb4d631fbb55b9bd24889312838cbd27cd33e14cc0c18405f007
 MAINTAINER Social Feed Manager <sfm@gwu.edu>
 
+ARG build_version=release
+
 # Install apache
 RUN apt-get update && apt-get install -y \
     apache2=2.4* \
@@ -9,7 +11,7 @@ RUN apt-get update && apt-get install -y \
 
 ADD . /opt/sfm-ui/
 WORKDIR /opt/sfm-ui
-RUN python -m pip install -r requirements/common.txt -r requirements/release.txt
+RUN python -m pip install -r requirements/common.txt -r requirements/${build_version}.txt
 
 # Adds fixtures.
 ADD docker/ui/fixtures.json /opt/sfm-setup/

--- a/Dockerfile-consumer
+++ b/Dockerfile-consumer
@@ -2,9 +2,11 @@
 FROM gwul/sfm-base@sha256:0b80a3d3562cdb4d631fbb55b9bd24889312838cbd27cd33e14cc0c18405f007
 MAINTAINER Social Feed Manager <sfm@gwu.edu>
 
+ARG build_version=release
+
 ADD . /opt/sfm-ui/
 WORKDIR /opt/sfm-ui
-RUN pip install -r requirements/common.txt -r requirements/release.txt
+RUN pip install -r requirements/common.txt -r requirements/${build_version}.txt
 
 ADD docker/consumer/invoke_consumer.sh /opt/sfm-setup/
 RUN chmod +x /opt/sfm-setup/invoke_consumer.sh

--- a/Dockerfile-runserver
+++ b/Dockerfile-runserver
@@ -2,9 +2,11 @@
 FROM gwul/sfm-base@sha256:0b80a3d3562cdb4d631fbb55b9bd24889312838cbd27cd33e14cc0c18405f007
 MAINTAINER Social Feed Manager <sfm@gwu.edu>
 
+ARG build_version=release
+
 ADD . /opt/sfm-ui/
 WORKDIR /opt/sfm-ui
-RUN pip install -r requirements/common.txt -r requirements/release.txt
+RUN pip install -r requirements/common.txt -r requirements/${build_version}.txt
 
 # Adds fixtures.
 ADD docker/ui/fixtures.json /opt/sfm-setup/

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -4,8 +4,8 @@ django-allauth==0.41.0
 django-braces==1.14.0
 django-crispy-forms==1.9.0
 django-datatables-view==1.18.0
-django-filter==2.2.0
-django-simple-history==2.7.3
+django-filter==21.1
+django-simple-history==3.2.0
 djangorestframework~=3.11.2
 iso8601==0.1.12
 jsonfield==3.1.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,5 +1,5 @@
 APScheduler==3.7.0
-django==2.2.24
+django==3.2.16
 django-allauth==0.41.0
 django-braces==1.14.0
 django-crispy-forms==1.9.0
@@ -10,7 +10,7 @@ djangorestframework~=3.11.2
 iso8601==0.1.12
 jsonfield==3.1.0
 psycopg2-binary==2.8.4
-pytz==2019.3
+pytz==2022.1
 rabbitmq-admin==0.2
 SQLAlchemy==1.3.5
 # Used when executing SQL in migration.

--- a/sfm/sfm/settings/common.py
+++ b/sfm/sfm/settings/common.py
@@ -290,3 +290,5 @@ SFM_UI_VERSION = "2.5.0"
 PRIORITY_SCHEDULE_MINUTES = 60
 # Harvest types that support priority queues.
 PRIORITY_HARVEST_TYPES = ['twitter_search', 'twitter_user_timeline']
+# For Django 3.2, recommended to set the autofield for primary-key columns explicitly
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/sfm/ui/forms.py
+++ b/sfm/ui/forms.py
@@ -342,8 +342,6 @@ class CollectionTwitterFilterForm(BaseCollectionForm):
         m.save()
         return m
 
-#code for filter stream
-
 class CollectionTwitterFilterStreamForm(BaseCollectionForm):
     class Meta(BaseCollectionForm.Meta):
         exclude = ('schedule_minutes',)
@@ -357,10 +355,6 @@ class CollectionTwitterFilterStreamForm(BaseCollectionForm):
         m.schedule_minutes = None
         m.save()
         return m
-
-
-#code end for filter stream        
-
 
 
 
@@ -904,37 +898,47 @@ class SeedTwitterFilterForm(BaseSeedForm):
         return m
 
 
-#Code for filter stream
-
 class SeedTwitterFilterStreamForm(BaseSeedForm):
-    rule = forms.CharField(required=False, widget=forms.Textarea(attrs={'rows': 4}),
+    rule = forms.CharField(required=True, widget=forms.Textarea(attrs={'rows': 4}),
                             help_text="""Enter a streaming rule to select Tweets during your streaming harvest. See the <a href="https://developer.twitter.com/en/docs/twitter-api/tweets/filtered-stream/integrate/build-a-rule" target="_blank">Twitter API documentation</a> for guidance on creating rules. 
                             """)
+    
+    tag = forms.CharField(required=False, widget=forms.Textarea(attrs={'rows': 1}),
+                            help_text="""Enter a tag for your rule. Tags will appear in exported data for this collection.""")
 
     def __init__(self, *args, **kwargs):
         super(SeedTwitterFilterStreamForm, self).__init__(*args, **kwargs)
-        self.helper.layout[0][0].extend(('rule',))
+        self.helper.layout[0][0].extend(("rule","tag"))
 
         if self.instance and self.instance.token:
             token = json.loads(self.instance.token)
-            if 'rule' in token:
-                self.fields['rule'].initial = token['rule']
+            if "rule" in token:
+                self.fields["rule"].initial = token["rule"]
+            if "tag" in token:
+                self.fields["tag"].initial = token["tag"]
 
     def clean_rule(self):
         rule_val = self.cleaned_data.get("rule").strip()
         return rule_val
+    
+    def clean_tag(self):
+        tag_val = self.cleaned_data.get("tag").strip()
+        return tag_val
 
     def clean(self):
         # if do string strip in here, string ends an empty space, not sure why
         rule_val = self.cleaned_data.get("rule")
+        tag_val = self.cleaned_data.get("tag")
 
         # should not all be empty
         if not rule_val:
-            raise ValidationError(u'A streaming rule is required.')
+            raise ValidationError(u"A streaming rule is required.")
 
         token_val = {}
         if rule_val:
-            token_val['rule'] = rule_val
+            token_val["rule"] = rule_val
+        if tag_val:
+            token_val["tag"] = tag_val
         token_val = json.dumps(token_val, ensure_ascii=False)
         # for the update view
         if self.view_type == Seed.UPDATE_VIEW:
@@ -951,12 +955,13 @@ class SeedTwitterFilterStreamForm(BaseSeedForm):
     def save(self, commit=True):
         m = super(SeedTwitterFilterStreamForm, self).save(commit=False)
         token = dict()
-        if self.cleaned_data['rule']:
-            token['rule'] = self.cleaned_data['rule']
+        if self.cleaned_data["rule"]:
+            token["rule"] = self.cleaned_data["rule"]
+        if self.cleaned_data["tag"]:
+            token["tag"] = self.cleaned_data["tag"]
         m.token = json.dumps(token, ensure_ascii=False)
         m.save()
         return m
-#code end for filter stream        
 
 class SeedFlickrUserForm(BaseSeedForm):
     class Meta(BaseSeedForm.Meta):

--- a/sfm/ui/forms.py
+++ b/sfm/ui/forms.py
@@ -1417,7 +1417,7 @@ class ExportForm(forms.ModelForm):
                        onclick="window.location.href='{0}'".format(cancel_url))
             )
         )
-        if len(self.fields["seeds"].queryset) < 2:
+        if (len(self.fields["seeds"].queryset) < 2) or (self.collection.harvest_type == 'twitter_filter_stream'):
             del self.fields["seeds"]
             del self.fields["seed_choice"]
             self.helper.layout[0].pop(0)

--- a/sfm/ui/forms.py
+++ b/sfm/ui/forms.py
@@ -911,6 +911,25 @@ class SeedTwitterFilterStreamForm(BaseSeedForm):
                             help_text="""Separate keywords and phrases with commas. See Twitter <a
                             target="_blank" href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters#track">
                             track</a> for more information.""")
+    follow = forms.CharField(required=False, widget=forms.Textarea(attrs={'rows': 4}),
+                             help_text="""Use commas to separate user IDs (e.g. 1233718,6378678) of accounts whose
+                             tweets, retweets, and replies will be collected. See Twitter <a
+                             target="_blank"
+                             href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters#follow">
+                             follow</a>
+                             documentation for a full list of what is returned. User <a target="_blank"
+                             href="https://tweeterid.com/">TweeterID</a> to get the user ID for a screen name.""")
+    locations = forms.CharField(required=False, widget=forms.Textarea(attrs={'rows': 2}),
+                                help_text="""Provide a longitude and latitude (e.g. -74,40,-73,41) of a geographic
+                                bounding box. See Twitter <a target="blank"
+                                href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters#locations">
+                                locations</a> for more information.""")
+
+    language = forms.CharField(required=False, widget=forms.Textarea(attrs={'rows': 2}),
+                               help_text="""Provide a comma-separated list of two-letter <a target="blank"
+                               href="https://datahub.io/core/language-codes">BCP 47 language codes</a> (e.g. en,es). See Twitter <a target="blank"
+                               href="https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/basic-stream-parameters#language">
+                               language</a> for more information.""")
 
     def __init__(self, *args, **kwargs):
         super(SeedTwitterFilterStreamForm, self).__init__(*args, **kwargs)
@@ -933,10 +952,32 @@ class SeedTwitterFilterStreamForm(BaseSeedForm):
             raise ValidationError("Can only track 400 keywords.")
         return track_val
 
+    def clean_locations(self):
+        return self.cleaned_data.get("locations").strip()
+
+    def clean_language(self):
+        return self.cleaned_data.get("language").strip()
+
+    def clean_follow(self):
+        follow_val = self.cleaned_data.get("follow").strip()
+        if len(follow_val.split(",")) > 5000:
+            raise ValidationError("Can only follow 5000 users.")
+        return follow_val
 
     def clean(self):
         # if do string strip in here, string ends an empty space, not sure why
         track_val = self.cleaned_data.get("track")
+        follow_val = self.cleaned_data.get("follow")
+        locations_val = self.cleaned_data.get("locations")
+        language_val = self.cleaned_data.get("language")
+
+        # should not all be empty
+        if not track_val and not follow_val and not locations_val and not language_val:
+            raise ValidationError(u'One of the following fields is required: track, follow, locations, language.')
+
+        # check follow should be number uid
+        if re.compile(r'[^0-9, ]').search(follow_val):
+            raise ValidationError('Follow must be user ids', code='invalid_follow')
 
         token_val = {}
         if track_val:
@@ -965,11 +1006,15 @@ class SeedTwitterFilterStreamForm(BaseSeedForm):
         token = dict()
         if self.cleaned_data['track']:
             token['track'] = self.cleaned_data['track']
-
+        if self.cleaned_data['follow']:
+            token['follow'] = self.cleaned_data['follow']
+        if self.cleaned_data['locations']:
+            token['locations'] = self.cleaned_data['locations']
+        if self.cleaned_data['language']:
+            token['language'] = self.cleaned_data['language']
         m.token = json.dumps(token, ensure_ascii=False)
         m.save()
         return m
-
 #code end for filter stream        
 
 class SeedFlickrUserForm(BaseSeedForm):

--- a/sfm/ui/forms.py
+++ b/sfm/ui/forms.py
@@ -933,32 +933,10 @@ class SeedTwitterFilterStreamForm(BaseSeedForm):
             raise ValidationError("Can only track 400 keywords.")
         return track_val
 
-    def clean_locations(self):
-        return self.cleaned_data.get("locations").strip()
-
-    def clean_language(self):
-        return self.cleaned_data.get("language").strip()
-
-    def clean_follow(self):
-        follow_val = self.cleaned_data.get("follow").strip()
-        if len(follow_val.split(",")) > 5000:
-            raise ValidationError("Can only follow 5000 users.")
-        return follow_val
 
     def clean(self):
         # if do string strip in here, string ends an empty space, not sure why
         track_val = self.cleaned_data.get("track")
-        follow_val = self.cleaned_data.get("follow")
-        locations_val = self.cleaned_data.get("locations")
-        language_val = self.cleaned_data.get("language")
-
-        # should not all be empty
-        if not track_val and not follow_val and not locations_val and not language_val:
-            raise ValidationError(u'One of the following fields is required: track, follow, locations, language.')
-
-        # check follow should be number uid
-        if re.compile(r'[^0-9, ]').search(follow_val):
-            raise ValidationError('Follow must be user ids', code='invalid_follow')
 
         token_val = {}
         if track_val:
@@ -987,12 +965,7 @@ class SeedTwitterFilterStreamForm(BaseSeedForm):
         token = dict()
         if self.cleaned_data['track']:
             token['track'] = self.cleaned_data['track']
-        if self.cleaned_data['follow']:
-            token['follow'] = self.cleaned_data['follow']
-        if self.cleaned_data['locations']:
-            token['locations'] = self.cleaned_data['locations']
-        if self.cleaned_data['language']:
-            token['language'] = self.cleaned_data['language']
+
         m.token = json.dumps(token, ensure_ascii=False)
         m.save()
         return m

--- a/sfm/ui/models.py
+++ b/sfm/ui/models.py
@@ -299,6 +299,7 @@ class CollectionHistoryModel(models.Model):
 class Collection(models.Model):
     TWITTER_SEARCH = 'twitter_search'
     TWITTER_FILTER = "twitter_filter"
+    TWITTER_FILTER_STREAM = "twitter_filter_stream"
     TWITTER_USER_TIMELINE = 'twitter_user_timeline'
     TWITTER_SAMPLE = 'twitter_sample'
     TWITTER_ACADEMIC_SEARCH = 'twitter_academic_search'
@@ -322,6 +323,7 @@ class Collection(models.Model):
         (TWITTER_USER_TIMELINE, 'Twitter user timeline'),
         (TWITTER_SEARCH, 'Twitter search'),
         (TWITTER_FILTER, 'Twitter filter'),
+        (TWITTER_FILTER_STREAM, 'Twitter filter stream'),
         (TWITTER_SAMPLE, 'Twitter sample'),
         (TWITTER_ACADEMIC_SEARCH, 'Twitter academic search'),
         (TWITTER_SEARCH_2, 'Twitter search version 2'),
@@ -333,6 +335,7 @@ class Collection(models.Model):
     HARVEST_DESCRIPTION = {
         TWITTER_SEARCH: 'Recent tweets matching a query',
         TWITTER_FILTER: 'Tweets in real time matching filter criteria',
+        TWITTER_FILTER_STREAM: 'Tweets in real time matching filter stream criteria',
         TWITTER_USER_TIMELINE: 'Tweets from specific accounts',
         TWITTER_SAMPLE: 'A subset of all tweets in real time',
         TWITTER_ACADEMIC_SEARCH: 'Tweets from the full archive using Twitter Academic Research',
@@ -345,6 +348,7 @@ class Collection(models.Model):
     HARVEST_FIELDS = {
         TWITTER_SEARCH: {"link": None, "token": "Search query", "uid": None},
         TWITTER_FILTER: {"link": None, "token": "Filter criteria", "uid": None},
+        TWITTER_FILTER_STREAM: {"link": None, "token": "Filter stream criteria", "uid": None},
         TWITTER_USER_TIMELINE: {"link": "Link", "token": "Twitter accounts", "uid": "User ID"},
         TWITTER_SAMPLE: None,
         TWITTER_ACADEMIC_SEARCH: {"link": None, "token": "Search query", "uid": None},
@@ -356,6 +360,7 @@ class Collection(models.Model):
     }
     REQUIRED_SEED_COUNTS = {
         TWITTER_FILTER: 1,
+        TWITTER_FILTER_STREAM: 1,
         TWITTER_SEARCH: 1,
         TWITTER_ACADEMIC_SEARCH: 1,
         TWITTER_SEARCH_2: 1,
@@ -366,6 +371,7 @@ class Collection(models.Model):
     HARVEST_TYPES_TO_PLATFORM = {
         TWITTER_SEARCH: Credential.TWITTER,
         TWITTER_FILTER: Credential.TWITTER,
+        TWITTER_FILTER_STREAM: Credential.TWITTER2,
         TWITTER_USER_TIMELINE: Credential.TWITTER,
         TWITTER_SAMPLE: Credential.TWITTER,
         TWITTER_ACADEMIC_SEARCH: Credential.TWITTER2,
@@ -376,7 +382,7 @@ class Collection(models.Model):
         WEIBO_SEARCH: Credential.WEIBO,
         TUMBLR_BLOG_POSTS: Credential.TUMBLR
     }
-    STREAMING_HARVEST_TYPES = (TWITTER_SAMPLE, TWITTER_FILTER)
+    STREAMING_HARVEST_TYPES = (TWITTER_SAMPLE, TWITTER_FILTER,TWITTER_FILTER_STREAM)
     RATE_LIMITED_HARVEST_TYPES = (TWITTER_USER_TIMELINE, TWITTER_SEARCH, TWITTER_USER_TIMELINE_2, TWITTER_SEARCH_2, TWITTER_ACADEMIC_SEARCH)
     DEFAULT_VISIBILITY = 'default'
     LOCAL_VISIBILITY = 'local'

--- a/sfm/ui/models.py
+++ b/sfm/ui/models.py
@@ -301,7 +301,7 @@ class Collection(models.Model):
     TWITTER_FILTER = "twitter_filter"
     TWITTER_FILTER_STREAM = "twitter_filter_stream"
     TWITTER_USER_TIMELINE = 'twitter_user_timeline'
-    TWITTER_SAMPLE = 'twitter_sample'
+#    TWITTER_SAMPLE = 'twitter_sample'
     TWITTER_ACADEMIC_SEARCH = 'twitter_academic_search'
     TWITTER_SEARCH_2 = 'twitter_search_2'
     TWITTER_USER_TIMELINE_2 = 'twitter_user_timeline_2'
@@ -323,8 +323,8 @@ class Collection(models.Model):
         (TWITTER_USER_TIMELINE, 'Twitter user timeline'),
         (TWITTER_SEARCH, 'Twitter search'),
         (TWITTER_FILTER, 'Twitter filter'),
-        (TWITTER_FILTER_STREAM, 'Twitter filter stream'),
-        (TWITTER_SAMPLE, 'Twitter sample'),
+        (TWITTER_FILTER_STREAM, 'Twitter filtered stream'),
+        #(TWITTER_SAMPLE, 'Twitter sample'),
         (TWITTER_ACADEMIC_SEARCH, 'Twitter academic search'),
         (TWITTER_SEARCH_2, 'Twitter search version 2'),
         (TWITTER_USER_TIMELINE_2, 'Twitter user timeline version 2'),
@@ -335,9 +335,9 @@ class Collection(models.Model):
     HARVEST_DESCRIPTION = {
         TWITTER_SEARCH: 'Recent tweets matching a query',
         TWITTER_FILTER: 'Tweets in real time matching filter criteria',
-        TWITTER_FILTER_STREAM: 'Tweets in real time matching filter stream criteria',
+        TWITTER_FILTER_STREAM: 'Tweets in real time matching streaming rules',
         TWITTER_USER_TIMELINE: 'Tweets from specific accounts',
-        TWITTER_SAMPLE: 'A subset of all tweets in real time',
+#        TWITTER_SAMPLE: 'A subset of all tweets in real time',
         TWITTER_ACADEMIC_SEARCH: 'Tweets from the full archive using Twitter Academic Research',
         TWITTER_SEARCH_2: 'Recent tweets matching a query from the standard version 2 API',
         TWITTER_USER_TIMELINE_2: 'Tweets from specific accounts, from the version 2 API',
@@ -348,9 +348,9 @@ class Collection(models.Model):
     HARVEST_FIELDS = {
         TWITTER_SEARCH: {"link": None, "token": "Search query", "uid": None},
         TWITTER_FILTER: {"link": None, "token": "Filter criteria", "uid": None},
-        TWITTER_FILTER_STREAM: {"link": None, "token": "Filter stream criteria", "uid": None},
+        TWITTER_FILTER_STREAM: {"link": None, "token": "Streaming rules", "uid": None},
         TWITTER_USER_TIMELINE: {"link": "Link", "token": "Twitter accounts", "uid": "User ID"},
-        TWITTER_SAMPLE: None,
+#        TWITTER_SAMPLE: None,
         TWITTER_ACADEMIC_SEARCH: {"link": None, "token": "Search query", "uid": None},
         TWITTER_SEARCH_2: {"link": None, "token": "Search query", "uid": None},
         TWITTER_USER_TIMELINE_2: {"link": "Link", "token": "Twitter accounts", "uid": "User ID"},
@@ -365,7 +365,7 @@ class Collection(models.Model):
         TWITTER_ACADEMIC_SEARCH: 1,
         TWITTER_SEARCH_2: 1,
         WEIBO_SEARCH: 1,
-        TWITTER_SAMPLE: 0,
+#        TWITTER_SAMPLE: 0,
         WEIBO_TIMELINE: 0
     }
     HARVEST_TYPES_TO_PLATFORM = {
@@ -373,7 +373,7 @@ class Collection(models.Model):
         TWITTER_FILTER: Credential.TWITTER,
         TWITTER_FILTER_STREAM: Credential.TWITTER2,
         TWITTER_USER_TIMELINE: Credential.TWITTER,
-        TWITTER_SAMPLE: Credential.TWITTER,
+#        TWITTER_SAMPLE: Credential.TWITTER,
         TWITTER_ACADEMIC_SEARCH: Credential.TWITTER2,
         TWITTER_SEARCH_2: Credential.TWITTER2,
         TWITTER_USER_TIMELINE_2: Credential.TWITTER2,
@@ -382,7 +382,7 @@ class Collection(models.Model):
         WEIBO_SEARCH: Credential.WEIBO,
         TUMBLR_BLOG_POSTS: Credential.TUMBLR
     }
-    STREAMING_HARVEST_TYPES = (TWITTER_SAMPLE, TWITTER_FILTER,TWITTER_FILTER_STREAM)
+    STREAMING_HARVEST_TYPES = (TWITTER_FILTER,TWITTER_FILTER_STREAM)
     RATE_LIMITED_HARVEST_TYPES = (TWITTER_USER_TIMELINE, TWITTER_SEARCH, TWITTER_USER_TIMELINE_2, TWITTER_SEARCH_2, TWITTER_ACADEMIC_SEARCH)
     DEFAULT_VISIBILITY = 'default'
     LOCAL_VISIBILITY = 'local'

--- a/sfm/ui/models.py
+++ b/sfm/ui/models.py
@@ -360,7 +360,7 @@ class Collection(models.Model):
     }
     REQUIRED_SEED_COUNTS = {
         TWITTER_FILTER: 1,
-        TWITTER_FILTER_STREAM: 1,
+        TWITTER_FILTER_STREAM: None,  # allowed seeds depend on user's access level
         TWITTER_SEARCH: 1,
         TWITTER_ACADEMIC_SEARCH: 1,
         TWITTER_SEARCH_2: 1,

--- a/sfm/ui/views.py
+++ b/sfm/ui/views.py
@@ -16,7 +16,7 @@ from django.db.models import Q
 from braces.views import LoginRequiredMixin
 from allauth.socialaccount.models import SocialApp
 from django_datatables_view.base_datatable_view import BaseDatatableView
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.utils.html import mark_safe
 from django.conf import settings
 

--- a/sfm/ui/views.py
+++ b/sfm/ui/views.py
@@ -315,8 +315,9 @@ class CollectionDetailView(LoginRequiredMixin, CollectionSetOrCollectionVisibili
             if credential_used_col_object.count() != 0:
                 credential_used_col = credential_used_col_object[0]
         context["credential_used_col"] = credential_used_col
-        # Harvest types that are not limited support bulk add
-        context["can_add_bulk_seeds"] = self.object.required_seed_count() is None
+        # Harvest types that are not limited support bulk add, except for Twitter v2. filter stream
+        # To do --> support bulk add for streaming rules
+        context["can_add_bulk_seeds"] = (self.object.required_seed_count() is None) and (self.object.harvest_type != 'twitter_filter_stream')
         # Can export if there is a WARC
         context["can_export"] = Warc.objects.filter(harvest__harvest_type=self.object.harvest_type,
                                                     harvest__historical_collection__id=self.object.id).exists()


### PR DESCRIPTION
Resolves #1126 
Resolves #1105 

### Contains
- Upgrade to Django 3.2 (and dependencies)
- Forms for Twitter v.2 Filtered Stream 
  - collection form
  - seed form
- Removal of Twitter v.1 Sample collection type (deprecated)

### Testing
- Verify that user can create SFM account and add credentials (both Twitter v1 and Twitter v2)
- Verify creation of Twitter v1 collections: Search, Filter, User Timeline
- Verify that the Sample collection type is unavailable
- Verify creation of Twitter v2 collections: Search (2), Academic Search, Filtered Stream, User Timeline (2)
- Verify creation of seeds for the above collection types
- For Filtered Stream collection, verify that user can add multiple streaming rules
   - `rule` field should be required 
   - `tag` field should be optional
   - Verify that user can edit rules already created 